### PR TITLE
Fix blank screen and add offline localStorage support

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,8 +1,8 @@
-import { initializeApp } from 'firebase/app'
-import { getFirestore } from 'firebase/firestore'
+import { initializeApp, FirebaseApp } from 'firebase/app'
+import { getFirestore, Firestore } from 'firebase/firestore'
 
 // Firebase設定の検証
-function validateFirebaseConfig() {
+function isFirebaseConfigured(): boolean {
   const requiredEnvVars = [
     'VITE_FIREBASE_API_KEY',
     'VITE_FIREBASE_AUTH_DOMAIN',
@@ -17,44 +17,53 @@ function validateFirebaseConfig() {
   )
 
   if (missingVars.length > 0) {
-    console.error(
-      '⚠️  Firebase configuration error: Missing environment variables:',
+    console.warn(
+      '⚠️  Firebase not configured. Missing environment variables:',
       missingVars.join(', ')
     )
-    console.error(
-      '📝 Please create a .env.local file and set the following variables:'
+    console.warn(
+      '📝 App will run in offline mode using localStorage.'
     )
-    console.error('   - VITE_FIREBASE_API_KEY')
-    console.error('   - VITE_FIREBASE_AUTH_DOMAIN')
-    console.error('   - VITE_FIREBASE_PROJECT_ID')
-    console.error('   - VITE_FIREBASE_STORAGE_BUCKET')
-    console.error('   - VITE_FIREBASE_MESSAGING_SENDER_ID')
-    console.error('   - VITE_FIREBASE_APP_ID')
-    console.error(
-      '\nSee .env.example for reference or README.md for setup instructions.'
+    console.warn(
+      '   To enable Firebase, set the following variables in .env.local:'
     )
-
-    throw new Error(
-      `Firebase configuration error: Missing environment variables: ${missingVars.join(', ')}`
-    )
+    console.warn('   - VITE_FIREBASE_API_KEY')
+    console.warn('   - VITE_FIREBASE_AUTH_DOMAIN')
+    console.warn('   - VITE_FIREBASE_PROJECT_ID')
+    console.warn('   - VITE_FIREBASE_STORAGE_BUCKET')
+    console.warn('   - VITE_FIREBASE_MESSAGING_SENDER_ID')
+    console.warn('   - VITE_FIREBASE_APP_ID')
+    return false
   }
+
+  return true
 }
 
-// 環境変数の検証
-validateFirebaseConfig()
+// Firebase設定状態をエクスポート
+export const isFirebaseEnabled = isFirebaseConfigured()
 
-// Firebase設定
-const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID
+// Firebaseアプリを初期化（設定されている場合のみ）
+export let app: FirebaseApp | null = null
+export let db: Firestore | null = null
+
+if (isFirebaseEnabled) {
+  try {
+    const firebaseConfig = {
+      apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+      authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+      projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+      storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+      messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+      appId: import.meta.env.VITE_FIREBASE_APP_ID
+    }
+
+    app = initializeApp(firebaseConfig)
+    db = getFirestore(app)
+    console.log('✅ Firebase initialized successfully')
+  } catch (error) {
+    console.error('❌ Firebase initialization failed:', error)
+    console.warn('📝 Falling back to localStorage mode')
+  }
+} else {
+  console.log('📦 Running in offline mode with localStorage')
 }
-
-// Firebaseアプリを初期化
-export const app = initializeApp(firebaseConfig)
-
-// Firestoreインスタンスをエクスポート
-export const db = getFirestore(app)

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,6 +731,11 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz"
   integrity sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==
 
+"@rollup/rollup-linux-x64-musl@4.53.3":
+  version "4.53.3"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz"
+  integrity sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==
+
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"


### PR DESCRIPTION
- Modified Firebase initialization to be optional with graceful fallback
- Added localStorage support for offline/pre-login usage
- Store now works with both Firebase and localStorage
- All CRUD operations (add, update, delete, move, reorder) support both modes
- App will run offline if Firebase env vars are not configured
- No more blank screen errors on deployment without Firebase config