### PR TITLE
Fix date deletion bug and dark mode styling

### DIFF
--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -587,7 +587,7 @@ const EmptyState = styled.div<{ $theme: any }>`
   font-style: italic;
 `
 
-const DueDateInput = styled.input<{ $isOverdue?: boolean; $isDueSoon?: boolean; $theme: any; $isDarkMode?: boolean }>`
+const DueDateInput = styled.input<{ $isOverdue?: boolean; $isDueSoon?: boolean; $theme: Theme; $isDarkMode?: boolean }>`
   width: 100%;
   padding: 8px 12px;
   border: 1px solid ${props =>
@@ -599,11 +599,14 @@ const DueDateInput = styled.input<{ $isOverdue?: boolean; $isDueSoon?: boolean; 
   font-size: 14px;
   color: ${props => props.$theme.text};
   background-color: ${props => {
+    const overdueColors = { light: '#FFE5E5', dark: '#4A2020' }
+    const dueSoonColors = { light: '#FFF4E5', dark: '#4A3A20' }
+
     if (props.$isOverdue) {
-      return props.$isDarkMode ? '#4A2020' : '#FFE5E5'
+      return props.$isDarkMode ? overdueColors.dark : overdueColors.light
     }
     if (props.$isDueSoon) {
-      return props.$isDarkMode ? '#4A3A20' : '#FFF4E5'
+      return props.$isDarkMode ? dueSoonColors.dark : dueSoonColors.light
     }
     return props.$theme.inputBackground
   }};

--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -181,7 +181,8 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
       description,
       labels: selectedLabels,
       checklist,
-      dueDate: dueDate ? new Date(dueDate).getTime() : undefined,
+      // 日付が空の場合はnullを設定して削除を明示
+      dueDate: dueDate ? new Date(dueDate).getTime() : null,
       progress,
       color: cardColor
     })
@@ -330,6 +331,7 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
               $isOverdue={isOverdue}
               $isDueSoon={isDueSoon && !isOverdue}
               $theme={theme}
+              $isDarkMode={isDarkMode}
             />
             {isOverdue && <WarningText>期限切れです</WarningText>}
             {isDueSoon && !isOverdue && <WarningText $warning>まもなく期限です</WarningText>}
@@ -585,7 +587,7 @@ const EmptyState = styled.div<{ $theme: any }>`
   font-style: italic;
 `
 
-const DueDateInput = styled.input<{ $isOverdue?: boolean; $isDueSoon?: boolean; $theme: any }>`
+const DueDateInput = styled.input<{ $isOverdue?: boolean; $isDueSoon?: boolean; $theme: any; $isDarkMode?: boolean }>`
   width: 100%;
   padding: 8px 12px;
   border: 1px solid ${props =>
@@ -596,11 +598,16 @@ const DueDateInput = styled.input<{ $isOverdue?: boolean; $isDueSoon?: boolean; 
   border-radius: 4px;
   font-size: 14px;
   color: ${props => props.$theme.text};
-  background-color: ${props =>
-    props.$isOverdue ? '#FFE5E5' :
-    props.$isDueSoon ? '#FFF4E5' :
-    props.$theme.inputBackground
-  };
+  background-color: ${props => {
+    if (props.$isOverdue) {
+      return props.$isDarkMode ? '#4A2020' : '#FFE5E5'
+    }
+    if (props.$isDueSoon) {
+      return props.$isDarkMode ? '#4A3A20' : '#FFF4E5'
+    }
+    return props.$theme.inputBackground
+  }};
+  color-scheme: ${props => props.$isDarkMode ? 'dark' : 'light'};
 
   &:focus {
     outline: 2px solid ${color.Blue};

--- a/src/CardFilter.tsx
+++ b/src/CardFilter.tsx
@@ -93,12 +93,29 @@ const Input = styled.input.attrs({ type: 'search' })`
 const LabelsContainer = styled.div`
   display: flex;
   gap: 6px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
+  overflow-x: auto;
+  max-width: 400px;
+  padding-bottom: 4px;
+
+  /* スクロールバーを細くする */
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 2px;
+  }
 
   @media (max-width: 768px) {
     width: 100%;
+    max-width: 100%;
     margin-top: 8px;
+    flex-wrap: wrap;
+    overflow-x: visible;
+    padding-bottom: 0;
   }
 `
 
@@ -113,6 +130,11 @@ const LabelChip = styled.button<{ $color: string; $isSelected: boolean }>`
   cursor: pointer;
   transition: all 0.2s;
   opacity: ${props => props.$isSelected ? 1 : 0.7};
+  white-space: nowrap;
+  flex-shrink: 0;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &:hover {
     opacity: 1;

--- a/src/store/kanbanStore.ts
+++ b/src/store/kanbanStore.ts
@@ -182,20 +182,15 @@ export const useKanbanStore = create<KanbanState>((set, get) => ({
         }, true) // forFirestore = true
         await updateDoc(cardRef, cleanedUpdates)
       } else {
-        // LocalStorage mode - nullの場合はundefinedに変換してフィールドを削除
+        // LocalStorage mode - nullの場合はフィールドを削除
         const currentCards = get().cards
-        const cleanedUpdates: Record<string, unknown> = {}
-        for (const key in updates) {
-          const value = (updates as Record<string, unknown>)[key]
-          if (value !== null) {
-            cleanedUpdates[key] = value
-          }
-          // nullの場合はフィールドを含めない（undefinedとして扱う）
-        }
         const updatedCards = currentCards.map(card => {
-          if (card.id !== id) return card
-          // 既存のカードからnullで指定されたフィールドを削除
-          const newCard = { ...card, ...cleanedUpdates, updatedAt: Date.now() }
+          if (card.id !== id) {
+            return card
+          }
+
+          const newCard = { ...card, ...updates, updatedAt: Date.now() }
+
           for (const key in updates) {
             if ((updates as Record<string, unknown>)[key] === null) {
               delete (newCard as Record<string, unknown>)[key]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,7 +27,7 @@ export interface Card {
   labels?: Label[]
   color?: string
   checklist?: ChecklistItem[]
-  dueDate?: number
+  dueDate?: number | null  // nullは明示的な削除を表す
   progress?: number
 }
 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -3,7 +3,7 @@ import { ONE_DAY_MS } from '../constants'
 /**
  * Check if a due date is coming soon (within 24 hours)
  */
-export function isDueSoon(dueDate: number | undefined): boolean {
+export function isDueSoon(dueDate: number | null | undefined): boolean {
   if (!dueDate) return false
   return dueDate < Date.now() + ONE_DAY_MS && dueDate >= Date.now()
 }
@@ -11,7 +11,7 @@ export function isDueSoon(dueDate: number | undefined): boolean {
 /**
  * Check if a due date is overdue
  */
-export function isOverdue(dueDate: number | undefined): boolean {
+export function isOverdue(dueDate: number | null | undefined): boolean {
   if (!dueDate) return false
   return dueDate < Date.now()
 }
@@ -19,7 +19,7 @@ export function isOverdue(dueDate: number | undefined): boolean {
 /**
  * Get due date status
  */
-export function getDueDateStatus(dueDate: number | undefined): {
+export function getDueDateStatus(dueDate: number | null | undefined): {
   isDueSoon: boolean
   isOverdue: boolean
 } {


### PR DESCRIPTION
- 日付削除バグ: nullを明示的に使用してFirestoreのdeleteField()でフィールド削除
- ダークモード: 期限警告色をダークモード対応（#4A2020, #4A3A20）
- color-schemeプロパティでブラウザのdate pickerもダークモード対応
- ラベルヘッダー: 横スクロールに変更してヘッダー高さを固定
- LabelChipにtext-overflow: ellipsisを追加