### PR TITLE
feat: カード詳細モーダルに作成日時・更新日時を表示

### DIFF
--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -470,6 +470,17 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
           </Section>
         </Content>
 
+        <DateFooter $theme={theme}>
+          <DateItem>
+            <DateLabel $theme={theme}>作成</DateLabel>
+            <DateValue $theme={theme}>{new Date(card.createdAt).toLocaleString('ja-JP')}</DateValue>
+          </DateItem>
+          <DateItem>
+            <DateLabel $theme={theme}>更新</DateLabel>
+            <DateValue $theme={theme}>{new Date(card.updatedAt).toLocaleString('ja-JP')}</DateValue>
+          </DateItem>
+        </DateFooter>
+
         <Footer $theme={theme}>
           <SaveButton onClick={handleSave}>保存</SaveButton>
           <CancelButton onClick={onClose} $theme={theme}>キャンセル</CancelButton>
@@ -869,6 +880,32 @@ const ChecklistInput = styled.input<{ $theme: any }>`
 `
 
 const AddButton = styled(SmallPrimaryButton)``
+
+const DateFooter = styled.div<{ $theme: any }>`
+  display: flex;
+  gap: 16px;
+  padding: 8px 20px;
+  border-top: 1px solid ${props => props.$theme.border};
+  background-color: ${props => props.$theme.surfaceHover};
+  flex-shrink: 0;
+`
+
+const DateItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`
+
+const DateLabel = styled.span<{ $theme: any }>`
+  font-size: 11px;
+  font-weight: 600;
+  color: ${props => props.$theme.textSecondary};
+`
+
+const DateValue = styled.span<{ $theme: any }>`
+  font-size: 11px;
+  color: ${props => props.$theme.textSecondary};
+`
 
 const Footer = styled.div<{ $theme: any }>`
   display: flex;


### PR DESCRIPTION
カードの詳細モーダル下部に作成日時と更新日時をフッターとして表示。
既存の createdAt / updatedAt フィールドを ja-JP ロケールで表示する。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI表示の追加のみで、永続化ロジックや権限/データモデルには触れていません。
> 
> **Overview**
> カード詳細モーダルの下部に**作成日時/更新日時**を表示するフッター（`DateFooter`）を追加し、`card.createdAt`/`card.updatedAt` を `toLocaleString('ja-JP')` で整形して表示するようにしました。
> 
> 合わせて日時表示用のスタイル（`DateFooter`/`DateItem`/`DateLabel`/`DateValue`）を追加し、既存の保存/キャンセルフッターの直前に配置しています。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6dd38f32262210797803d051f51b2b7f13f630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->