### PR TITLE
feat: カード詳細モーダルに作成日時・更新日時を表示

### DIFF
--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -470,6 +470,17 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
           </Section>
         </Content>
 
+        <DateFooter $theme={theme}>
+          <DateItem>
+            <DateLabel $theme={theme}>作成</DateLabel>
+            <DateValue $theme={theme}>{new Date(card.createdAt).toLocaleString('ja-JP')}</DateValue>
+          </DateItem>
+          <DateItem>
+            <DateLabel $theme={theme}>更新</DateLabel>
+            <DateValue $theme={theme}>{new Date(card.updatedAt).toLocaleString('ja-JP')}</DateValue>
+          </DateItem>
+        </DateFooter>
+
         <Footer $theme={theme}>
           <SaveButton onClick={handleSave}>保存</SaveButton>
           <CancelButton onClick={onClose} $theme={theme}>キャンセル</CancelButton>
@@ -869,6 +880,32 @@ const ChecklistInput = styled.input<{ $theme: any }>`
 `
 
 const AddButton = styled(SmallPrimaryButton)``
+
+const DateFooter = styled.div<{ $theme: any }>`
+  display: flex;
+  gap: 16px;
+  padding: 8px 20px;
+  border-top: 1px solid ${props => props.$theme.border};
+  background-color: ${props => props.$theme.surfaceHover};
+  flex-shrink: 0;
+`
+
+const DateItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`
+
+const DateLabel = styled.span<{ $theme: any }>`
+  font-size: 11px;
+  font-weight: 600;
+  color: ${props => props.$theme.textSecondary};
+`
+
+const DateValue = styled.span<{ $theme: any }>`
+  font-size: 11px;
+  color: ${props => props.$theme.textSecondary};
+`
 
 const Footer = styled.div<{ $theme: any }>`
   display: flex;


### PR DESCRIPTION
## Summary
- カード詳細モーダルの保存ボタン上部に作成日時・更新日時を表示するフッターを追加
- 既存の `createdAt` / `updatedAt` フィールドを `ja-JP` ロケールで日本語フォーマット表示

## Test plan
- [ ] カードをクリックして詳細モーダルを開く
- [ ] モーダル下部に「作成」「更新」の日時が表示されることを確認
- [ ] 新規作成したカードの作成日時が正しく表示されることを確認
- [ ] カードを編集・保存後に更新日時が変わることを確認
- [ ] ダーク/ライトモード両方で表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 表示UIの追加のみで、データ更新ロジックや永続化には影響しないため低リスクです（`createdAt`/`updatedAt` が欠損している場合は表示が `Invalid Date` になり得る点は注意）。
> 
> **Overview**
> カード詳細モーダルのフッター（保存/キャンセルの直上）に、`createdAt`/`updatedAt` を `ja-JP` ロケールの日時表記で表示する **日時フッター** を追加しました。
> 
> 併せて、日時表示用の `DateFooter`/`DateItem`/`DateLabel`/`DateValue` のスタイルを追加し、テーマに合わせた境界線・背景・文字色を適用しています。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6dd38f32262210797803d051f51b2b7f13f630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カード詳細モーダルにカード作成日時と最終更新日時を表示する日付フッターセクションを追加しました。すべてのタイムスタンプは日本形式でフォーマットされています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->