### PR TITLE
feat: レーンヘッダーカラー・カスタムカラーピッカー・ヘッダー改善

### DIFF
--- a/src/Column.tsx
+++ b/src/Column.tsx
@@ -73,11 +73,13 @@ export function Column({
 
     return (
         <Container ref={setNodeRef} $theme={theme} $columnColor={columnColor} data-column-container>
-            <HeaderBar $columnColor={columnColor}>
+            <HeaderBar $columnColor={columnColor} $theme={theme}>
                 <CountBadge $theme={theme} $columnColor={columnColor}>
                     {cards.length}
                 </CountBadge>
-                <ColumnName $theme={theme}>{title}</ColumnName>
+                <ColumnName $theme={theme} $columnColor={columnColor}>
+                    {title}
+                </ColumnName>
                 {onToggleCollapse && (
                     <CollapseButton
                         onClick={(e) => {
@@ -85,12 +87,13 @@ export function Column({
                             onToggleCollapse()
                         }}
                         $theme={theme}
+                        $columnColor={columnColor}
                         title='レーンを畳む'
                     >
                         ‹
                     </CollapseButton>
                 )}
-                <AddButton onClick={toggleInput} $theme={theme} />
+                <AddButton onClick={toggleInput} $theme={theme} $columnColor={columnColor} />
             </HeaderBar>
 
             {inputMode && <InputForm value={text} onChange={setText} onConfirm={confirmInput} onCancel={cancelInput} />}
@@ -144,15 +147,18 @@ const Container = styled.div<{ $theme: Theme; $columnColor?: string }>`
     }
 `
 
-const HeaderBar = styled.div<{ $columnColor?: string }>`
+const HeaderBar = styled.div<{ $columnColor?: string; $theme: Theme }>`
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    padding: 12px 12px 8px 12px;
+    padding: 10px 12px;
     border-radius: 14px 14px 0 0;
     ${(props) =>
         props.$columnColor
-            ? `border-top: 3px solid ${props.$columnColor}; box-shadow: 0 2px 8px ${props.$columnColor}15;`
+            ? `
+        background: linear-gradient(135deg, ${props.$columnColor} 0%, ${props.$columnColor}CC 100%);
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+    `
             : ''}
 `
 
@@ -160,33 +166,35 @@ const CountBadge = styled.div<{ $theme: Theme; $columnColor?: string }>`
     margin-right: 8px;
     border-radius: 20px;
     padding: 2px 8px;
-    color: ${(props) => (props.$columnColor ? color.White : props.$theme.text)};
-    background-color: ${(props) => props.$columnColor || props.$theme.surface};
+    color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.95)' : props.$theme.text)};
+    background: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.2)' : props.$theme.surface)};
     font-size: 12px;
     font-weight: 600;
     line-height: 1.3;
+    backdrop-filter: ${(props) => (props.$columnColor ? 'blur(4px)' : 'none')};
 `
 
-const ColumnName = styled.div<{ $theme: Theme }>`
-    color: ${(props) => props.$theme.text};
+const ColumnName = styled.div<{ $theme: Theme; $columnColor?: string }>`
+    color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.95)' : props.$theme.text)};
     font-size: 14px;
     font-weight: 700;
     letter-spacing: 0.02em;
+    ${(props) => (props.$columnColor ? 'text-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);' : '')}
 `
 
 const AddButton = styled.button.attrs({
     type: 'button',
     children: <PlusIcon />,
-})<{ $theme: Theme }>`
+})<{ $theme: Theme; $columnColor?: string }>`
     margin-left: auto;
-    color: ${(props) => props.$theme.textSecondary};
+    color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.7)' : props.$theme.textSecondary)};
     padding: 4px;
     border-radius: 6px;
     transition: all 0.15s;
 
     :hover {
-        color: ${color.Blue};
-        background: ${(props) => props.$theme.surfaceHover};
+        color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 1)' : color.Blue)};
+        background: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.15)' : props.$theme.surfaceHover)};
     }
 `
 const InputForm = styled(_InputForm)`
@@ -286,8 +294,8 @@ const CollapsedTitle = styled.div<{ $theme: Theme }>`
     opacity: 0.85;
 `
 
-const CollapseButton = styled.button<{ $theme: Theme }>`
-    color: ${(props) => props.$theme.textSecondary};
+const CollapseButton = styled.button<{ $theme: Theme; $columnColor?: string }>`
+    color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.5)' : props.$theme.textSecondary)};
     padding: 2px 6px;
     border-radius: 6px;
     font-size: 16px;
@@ -297,12 +305,12 @@ const CollapseButton = styled.button<{ $theme: Theme }>`
     transition: all 0.15s ease;
 
     [data-column-container]:hover & {
-        opacity: 0.4;
+        opacity: 0.5;
     }
 
     &:hover {
         opacity: 1 !important;
-        color: ${(props) => props.$theme.text};
-        background: ${(props) => props.$theme.surfaceHover};
+        color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 1)' : props.$theme.text)};
+        background: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.15)' : props.$theme.surfaceHover)};
     }
 `

--- a/src/ColumnManager.tsx
+++ b/src/ColumnManager.tsx
@@ -122,6 +122,16 @@ function SortableColumnItem({ column, onEdit, onDelete, onColorChange, theme, ca
                             }}
                         />
                     ))}
+                    <CustomColorLabel $theme={theme} title='カスタムカラー'>
+                        <CustomColorInput
+                            type='color'
+                            value={column.color || '#2D5A8A'}
+                            onChange={(e) => {
+                                onColorChange(column.id, e.target.value)
+                            }}
+                        />
+                        <CustomColorIcon>⊕</CustomColorIcon>
+                    </CustomColorLabel>
                 </ColorPicker>
             )}
         </ColumnItemRow>
@@ -388,6 +398,38 @@ const ColorOption = styled.button<{ $color: string; $selected: boolean; $theme: 
     &:hover {
         transform: scale(1.15);
     }
+`
+
+const CustomColorLabel = styled.label<{ $theme: Theme }>`
+    position: relative;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px dashed ${(props) => props.$theme.border};
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s;
+
+    &:hover {
+        transform: scale(1.15);
+        border-color: ${(props) => props.$theme.textSecondary};
+    }
+`
+
+const CustomColorInput = styled.input`
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+`
+
+const CustomColorIcon = styled.span`
+    font-size: 14px;
+    pointer-events: none;
+    opacity: 0.5;
 `
 
 const AddSection = styled.div`

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -70,15 +70,26 @@ export function Header({ className }: { className?: string }) {
 
     return (
         <Container className={className} $isDarkMode={isDarkMode}>
-            {/* ロゴ - 常に表示 */}
-            <Logo>Kanban board</Logo>
+            {/* 左グループ: ロゴ + ボード */}
+            <LeftGroup>
+                <Logo>Kanban board</Logo>
+                <DesktopOnly>
+                    <BoardSelector />
+                </DesktopOnly>
+            </LeftGroup>
 
-            {/* ボードセレクター - PC表示 */}
+            <Spacer />
+
+            {/* 右グループ: フィルター + アクション */}
             <DesktopOnly>
-                <BoardSelector />
+                <CardFilter />
             </DesktopOnly>
 
-            {/* テーマ切り替え - PC表示 */}
+            <DesktopOnly>
+                <HeaderDivider />
+            </DesktopOnly>
+
+            {/* アクションボタン群 */}
             <DesktopOnly>
                 <ThemeToggle
                     onClick={toggleDarkMode}
@@ -88,7 +99,6 @@ export function Header({ className }: { className?: string }) {
                 </ThemeToggle>
             </DesktopOnly>
 
-            {/* ゴミ箱ボタン - PC表示 */}
             <DesktopOnly>
                 <TrashButton onClick={() => setIsTrashModalOpen(true)} title='ゴミ箱'>
                     <TrashIcon />
@@ -96,7 +106,6 @@ export function Header({ className }: { className?: string }) {
                 </TrashButton>
             </DesktopOnly>
 
-            {/* ユーザー情報 - PC表示 */}
             {isFirebaseEnabled && user && (
                 <DesktopOnly>
                     <UserInfo>
@@ -107,13 +116,6 @@ export function Header({ className }: { className?: string }) {
                     </UserInfo>
                 </DesktopOnly>
             )}
-
-            <Spacer />
-
-            {/* フィルター - PC表示 */}
-            <DesktopOnly>
-                <CardFilter />
-            </DesktopOnly>
 
             {/* ハンバーガーメニューボタン - モバイル表示 */}
             <MobileMenuButton
@@ -224,6 +226,13 @@ const Logo = styled.div`
     }
 `
 
+const LeftGroup = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+`
+
 const DesktopOnly = styled.div`
     display: flex;
     align-items: center;
@@ -235,38 +244,46 @@ const DesktopOnly = styled.div`
 
 const Spacer = styled.div`
     flex: 1;
+    min-width: 8px;
+`
+
+const HeaderDivider = styled.div`
+    width: 1px;
+    height: 20px;
+    background: rgba(255, 255, 255, 0.12);
+    margin: 0 8px;
+    flex-shrink: 0;
 `
 
 const ThemeToggle = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: 12px;
-    padding: 8px;
+    margin-left: 4px;
+    padding: 7px;
     border: none;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.08);
     cursor: pointer;
-    font-size: 18px;
     border-radius: 8px;
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(255, 255, 255, 0.75);
     transition: all 0.2s;
 
     &:hover {
-        background: rgba(255, 255, 255, 0.2);
-        transform: scale(1.05);
+        background: rgba(255, 255, 255, 0.16);
+        color: rgba(255, 255, 255, 1);
     }
 
     svg {
-        width: 18px;
-        height: 18px;
+        width: 16px;
+        height: 16px;
     }
 `
 
 const UserInfo = styled.div`
     display: flex;
     align-items: center;
-    gap: 12px;
-    margin-left: 16px;
+    gap: 8px;
+    margin-left: 8px;
 `
 
 const UserInitial = styled.div`
@@ -458,24 +475,23 @@ const TrashButton = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: 12px;
-    padding: 8px;
+    margin-left: 4px;
+    padding: 7px;
     border: none;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.08);
     cursor: pointer;
-    font-size: 18px;
     border-radius: 8px;
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(255, 255, 255, 0.75);
     transition: all 0.2s;
 
     &:hover {
-        background: rgba(255, 255, 255, 0.2);
-        transform: scale(1.05);
+        background: rgba(255, 255, 255, 0.16);
+        color: rgba(255, 255, 255, 1);
     }
 
     svg {
-        width: 18px;
-        height: 18px;
+        width: 16px;
+        height: 16px;
     }
 `
 


### PR DESCRIPTION
## Summary
- レーンにカラー設定時、ヘッダー全体にグラデーション背景を適用（テキスト/アイコン自動調整）
- ColumnManagerにネイティブカラーピッカー追加（プリセット + 自由選択）
- アプリヘッダーを左右グループに分離、アイコンサイズ統一、区切り線でセクション明確化

## Test plan
- [ ] レーン管理でプリセット色を選択 → ヘッダー背景が変わること
- [ ] カスタムカラーピッカーで任意の色を選択できること
- [ ] 色なし選択でデフォルトに戻ること
- [ ] ダーク/ライト両テーマで視認性が良いこと
- [ ] ヘッダーの左右バランスが改善されていること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カラムのカラーピッカーにカスタムカラー選択機能を追加しました。

* **UI改善**
  * カラムヘッダーのスタイリングをカラムの色に応じて統一的に更新しました。
  * ヘッダーレイアウトを再構成し、ボタンとコントロールの配置を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->