### PR TITLE
perf: Header と Column に React.memo と useCallback を適用

### DIFF
--- a/src/Column.tsx
+++ b/src/Column.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, useMemo } from 'react'
+import { useState, memo, useMemo, useCallback } from 'react'
 import styled from 'styled-components'
 import { useDroppable } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
@@ -36,20 +36,20 @@ export const Column = memo(function Column({
     const [text, setText] = useState('')
     const [inputMode, setInputMode] = useState(false)
 
-    const toggleInput = () => setInputMode((v) => !v)
+    const toggleInput = useCallback(() => setInputMode((v) => !v), [])
 
-    const confirmInput = async () => {
+    const confirmInput = useCallback(async () => {
         if (text.trim() && boardId) {
             await addCard(text.trim(), id, boardId)
             setText('')
             setInputMode(false)
         }
-    }
+    }, [text, boardId, addCard, id])
 
-    const cancelInput = () => {
+    const cancelInput = useCallback(() => {
         setText('')
         setInputMode(false)
-    }
+    }, [])
 
     const cardIds = useMemo(() => cards.map((card) => card.id), [cards])
 

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, lazy, Suspense } from 'react'
+import { useState, useEffect, useCallback, memo, lazy, Suspense } from 'react'
 import styled from 'styled-components'
 import * as color from './color'
 import { CardFilter } from './CardFilter'
@@ -17,7 +17,7 @@ function getFirstChar(email: string): string {
     return email[0]?.toLowerCase() || ''
 }
 
-export function Header({ className }: { className?: string }) {
+export const Header = memo(function Header({ className }: { className?: string }) {
     const { isDarkMode, toggleDarkMode } = useThemeStore()
     const { user, logOut } = useAuthStore()
     const { trashedCards, loadTrash } = useTrashStore()
@@ -29,12 +29,12 @@ export function Header({ className }: { className?: string }) {
         loadTrash()
     }, [loadTrash])
 
-    const handleLogout = async () => {
+    const handleLogout = useCallback(async () => {
         if (window.confirm('ログアウトしますか？')) {
             await logOut()
             setIsMenuOpen(false)
         }
-    }
+    }, [logOut])
 
     // メニューを閉じるための副作用（クリック外・ESCキー）
     useEffect(() => {
@@ -192,7 +192,7 @@ export function Header({ className }: { className?: string }) {
             )}
         </Container>
     )
-}
+})
 
 const Container = styled.div<{ $isDarkMode?: boolean }>`
     display: flex;


### PR DESCRIPTION
## Summary
- Header を React.memo でラップして不要な再レンダリングを防止
- Header の handleLogout を useCallback でメモ化
- Column の toggleInput, confirmInput, cancelInput を useCallback でメモ化

## Test plan
- [x] TypeScript コンパイル (`npm run typecheck`)
- [x] ESLint チェック (`npm run lint`)
- [x] パフォーマンス向上を確認（不要な再レンダリングの削減）

🤖 Generated with [Claude Code](https://claude.com/claude-code)