### PR TITLE
perf: BaseModal, Auth, ReloadPrompt を React.memo でラップ

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
   ],
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': 'warn',

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, memo } from 'react'
 import styled from 'styled-components'
 import { useAuthStore } from './store/authStore'
 import { useThemeStore } from './store/themeStore'
@@ -8,7 +8,7 @@ interface AuthProps {
     onSkipAuth?: () => void
 }
 
-export function Auth({ onSkipAuth }: AuthProps) {
+export const Auth = memo(function Auth({ onSkipAuth }: AuthProps) {
     const [isSignUp, setIsSignUp] = useState(false)
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
@@ -207,7 +207,7 @@ export function Auth({ onSkipAuth }: AuthProps) {
             </FormCard>
         </Container>
     )
-}
+})
 
 const Container = styled.div<{ $theme: Theme }>`
     display: flex;

--- a/src/BaseModal.tsx
+++ b/src/BaseModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, ReactNode, useRef } from 'react'
+import { useEffect, ReactNode, useRef, memo } from 'react'
 import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 import { useThemeStore } from './store/themeStore'
@@ -21,7 +21,12 @@ function isIOS(): boolean {
     )
 }
 
-export function BaseModal({ onClose, children, maxWidth = '600px', mobileAlignTop = false }: BaseModalProps) {
+export const BaseModal = memo(function BaseModal({
+    onClose,
+    children,
+    maxWidth = '600px',
+    mobileAlignTop = false,
+}: BaseModalProps) {
     const { isDarkMode } = useThemeStore()
     const theme = getTheme(isDarkMode)
     const modalRef = useRef<HTMLDivElement>(null)
@@ -89,7 +94,7 @@ export function BaseModal({ onClose, children, maxWidth = '600px', mobileAlignTo
     )
 
     return createPortal(modalContent, document.body)
-}
+})
 
 const Overlay = styled.div<{ $mobileAlignTop: boolean }>`
     position: fixed;

--- a/src/ReloadPrompt.tsx
+++ b/src/ReloadPrompt.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, memo } from 'react'
 import styled from 'styled-components'
 import { getTheme, type Theme } from './theme'
 import { useThemeStore } from './store/themeStore'
@@ -9,7 +9,7 @@ interface ReloadPromptProps {
     onReload: () => void
 }
 
-export function ReloadPrompt({ isVisible, onReload }: ReloadPromptProps) {
+export const ReloadPrompt = memo(function ReloadPrompt({ isVisible, onReload }: ReloadPromptProps) {
     const isDarkMode = useThemeStore((state) => state.isDarkMode)
     const theme = getTheme(isDarkMode)
     const [isAnimating, setIsAnimating] = useState(false)
@@ -43,7 +43,7 @@ export function ReloadPrompt({ isVisible, onReload }: ReloadPromptProps) {
             </Modal>
         </Overlay>
     )
-}
+})
 
 const Overlay = styled.div<{ $theme: Theme; $isVisible: boolean }>`
     position: fixed;


### PR DESCRIPTION
## Summary
- BaseModal を React.memo でラップして不要な再レンダリングを防止
- Auth を React.memo でラップして不要な再レンダリングを防止
- ReloadPrompt を React.memo でラップして不要な再レンダリングを防止
- ESLint設定に 'react/prop-types': 'off' を追加（TypeScript使用のため不要）

## Test plan
- [x] TypeScript コンパイル (`npm run typecheck`)
- [x] ESLint チェック (`npm run lint`)
- [x] コンポーネントが正しくメモ化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)