### PR TITLE
fix: ラベルフィルターチップにcheckboxロールを追加してアクセシビリティを改善

### DIFF
--- a/src/CardFilter.tsx
+++ b/src/CardFilter.tsx
@@ -43,11 +43,12 @@ function SortableLabelChip({ label, isSelected, toggleLabelFilter }: SortableLab
                     toggleLabelFilter(label.id)
                 }
             }}
+            {...attributes}
+            {...listeners}
+            role='checkbox'
             aria-checked={isSelected}
             title={`${label.name} でフィルター`}
             aria-label={`${label.name} でフィルター`}
-            {...attributes}
-            {...listeners}
         >
             {label.name}
         </LabelChip>


### PR DESCRIPTION
## Summary
- LabelChipに`role="checkbox"`を追加してWCAG準拠を改善
- aria-checkedを使用している要素にroleが欠けていた問題を修正
- スクリーンリーダーが選択状態を正しく認識できるようになります

## Changes
- `src/CardFilter.tsx`: SortableLabelChipに`role="checkbox"`属性を追加

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] aria-checkedとrole="checkbox"が正しく設定されていることを確認

## Accessibility Impact
- スクリーンリーダーがラベルフィルターの選択状態を適切にアナウンス
- キーボードナビゲーションと組み合わせてアクセシビリティが向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)