### PR TITLE
perf: BoardSelectorのパフォーマンスを最適化

### DIFF
--- a/src/BoardSelector.tsx
+++ b/src/BoardSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, memo } from 'react'
+import { useState, memo, useMemo, useCallback } from 'react'
 import styled from 'styled-components'
 import * as color from './color'
 import { useBoardStore } from './store/boardStore'
@@ -10,22 +10,26 @@ export const BoardSelector = memo(function BoardSelector() {
     const [isModalOpen, setIsModalOpen] = useState(false)
     const [editingBoard, setEditingBoard] = useState<string | null>(null)
 
-    const currentBoard = boards.find((b) => b.id === currentBoardId)
+    // currentBoardの検索を最適化
+    const currentBoard = useMemo(() => boards.find((b) => b.id === currentBoardId), [boards, currentBoardId])
 
-    const handleBoardChange = (boardId: string) => {
-        setCurrentBoardId(boardId)
-    }
+    const handleBoardChange = useCallback(
+        (boardId: string) => {
+            setCurrentBoardId(boardId)
+        },
+        [setCurrentBoardId]
+    )
 
-    const handleEditBoard = (e: React.MouseEvent, boardId: string) => {
+    const handleEditBoard = useCallback((e: React.MouseEvent, boardId: string) => {
         e.stopPropagation()
         setEditingBoard(boardId)
         setIsModalOpen(true)
-    }
+    }, [])
 
-    const handleCloseModal = () => {
+    const handleCloseModal = useCallback(() => {
         setIsModalOpen(false)
         setEditingBoard(null)
-    }
+    }, [])
 
     return (
         <>


### PR DESCRIPTION
## Summary
- BoardSelectorコンポーネントのパフォーマンスを最適化
- useMemoとuseCallbackを使用して不要な再レンダリングを防止

## Changes
- `currentBoard`の検索を`useMemo`で最適化
  - boards配列の変更時のみ再計算
- イベントハンドラーを`useCallback`でメモ化
  - `handleBoardChange`: setCurrentBoardId依存
  - `handleEditBoard`: 依存なし
  - `handleCloseModal`: 依存なし

## Performance Impact
- ボード切り替え時の不要な再レンダリングを削減
- 子コンポーネントへのprops変更を最小化
- React.memoと組み合わせて最適化効果を発揮

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)