### PR TITLE
perf: LinkedTextのパフォーマンスを最適化

### DIFF
--- a/src/LinkedText.tsx
+++ b/src/LinkedText.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import { parseUrls } from './utils/urlUtils'
 import type { UrlMetadata } from './types'
@@ -22,44 +22,52 @@ type Segment = {
  * テキスト内のURLを検出し、ハイパーリンクとして表示するコンポーネント
  */
 export const LinkedText = React.memo(function LinkedText({ text, metadata = [], theme, className }: LinkedTextProps) {
-    const urls = parseUrls(text)
+    const urls = useMemo(() => parseUrls(text), [text])
 
-    if (urls.length === 0) {
-        return <span className={className}>{text}</span>
-    }
+    const segments = useMemo(() => {
+        if (urls.length === 0) {
+            return null
+        }
 
-    // テキストをプレーンテキストとリンクのセグメントに分割
-    const segments: Segment[] = []
-    let lastIndex = 0
+        // テキストをプレーンテキストとリンクのセグメントに分割
+        const segs: Segment[] = []
+        let lastIndex = 0
 
-    urls.forEach(({ url, startIndex, endIndex }) => {
-        // URL前のプレーンテキスト
-        if (startIndex > lastIndex) {
-            segments.push({
+        urls.forEach(({ url, startIndex, endIndex }) => {
+            // URL前のプレーンテキスト
+            if (startIndex > lastIndex) {
+                segs.push({
+                    type: 'text',
+                    content: text.slice(lastIndex, startIndex),
+                })
+            }
+
+            // リンクセグメント
+            const meta = metadata.find((m) => m.url === url)
+            const displayText = meta?.title || url
+
+            segs.push({
+                type: 'link',
+                url,
+                displayText,
+            })
+
+            lastIndex = endIndex
+        })
+
+        // 残りのテキスト
+        if (lastIndex < text.length) {
+            segs.push({
                 type: 'text',
-                content: text.slice(lastIndex, startIndex),
+                content: text.slice(lastIndex),
             })
         }
 
-        // リンクセグメント
-        const meta = metadata.find((m) => m.url === url)
-        const displayText = meta?.title || url
+        return segs
+    }, [urls, text, metadata])
 
-        segments.push({
-            type: 'link',
-            url,
-            displayText,
-        })
-
-        lastIndex = endIndex
-    })
-
-    // 残りのテキスト
-    if (lastIndex < text.length) {
-        segments.push({
-            type: 'text',
-            content: text.slice(lastIndex),
-        })
+    if (!segments) {
+        return <span className={className}>{text}</span>
     }
 
     return (


### PR DESCRIPTION
## Summary
- LinkedTextコンポーネントのパフォーマンスを最適化
- useMemoを使用してURL解析とセグメント構築をメモ化

## Changes
- URL解析を`useMemo`でメモ化
  - `parseUrls(text)`の結果をキャッシュ
  - text変更時のみ再計算
- セグメント構築を`useMemo`でメモ化
  - urls/text/metadata変更時のみ再計算
  - 文字列処理の不要な再実行を防止

## Performance Impact
- カード詳細表示時のURL解析処理を最適化
- 特にURLを含む長文テキストでのパフォーマンス向上
- 不要な文字列処理を削減

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)