### PR TITLE
a11y: 折りたたみレーンのキーボードナビゲーションを改善

### DIFF
--- a/src/Column.tsx
+++ b/src/Column.tsx
@@ -58,10 +58,18 @@ export const Column = memo(function Column({
             <CollapsedColumn
                 ref={setNodeRef}
                 onClick={onToggleCollapse}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onToggleCollapse?.()
+                    }
+                }}
+                role='button'
+                tabIndex={0}
                 $theme={theme}
                 $columnColor={columnColor}
-                title={`${title} (${cards.length}) - クリックで展開`}
-                aria-label={`${title} (${cards.length}) - クリックで展開`}
+                title={`${title} (${cards.length}) - クリックまたはEnterキーで展開`}
+                aria-label={`${title} (${cards.length}) - クリックまたはEnterキーで展開`}
             >
                 <CollapsedCount $theme={theme} $columnColor={columnColor}>
                     {cards.length}


### PR DESCRIPTION
## Summary
- 折りたたまれたレーンをキーボードで展開できるようにアクセシビリティを改善
- WCAG 2.1準拠のキーボードナビゲーションを実装

## Changes
- `CollapsedColumn`に`role="button"`を追加
- `tabIndex={0}`を追加してキーボードフォーカス可能に
- `onKeyDown`ハンドラーを追加してEnterキーとSpaceキーで展開
- aria-labelとtitleを更新してキーボード操作を説明

## Accessibility Impact
- マウスを使用できないユーザーがキーボードのみでレーンを展開可能に
- スクリーンリーダーがボタンとして正しく認識
- Tabキーでフォーカス、EnterまたはSpaceで操作という標準的なパターンに準拠

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] キーボード操作（Tab、Enter、Space）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)