### PR TITLE
refactor: カラーパレット定数の重複を削減

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,17 +27,8 @@ export const LABEL_COLORS = [
     '#D53F8C', // Rose (Fun用)
 ]
 
-// Card color palette (ラベルと完全一致)
-export const CARD_COLORS = [
-    '#D69E2E', // Gold
-    '#38A169', // Emerald
-    '#E53E3E', // Ruby
-    '#3182CE', // Sapphire
-    '#805AD5', // Amethyst
-    '#DD6B20', // Amber
-    '#718096', // Slate
-    '#D53F8C', // Rose
-]
+// Card color palette (ラベルと完全一致のため、LABEL_COLORSを参照)
+export const CARD_COLORS = LABEL_COLORS
 
 // Card color labels (各色の意味づけ)
 export const CARD_COLOR_LABELS = [


### PR DESCRIPTION
## Summary
- カラーパレット定数の重複を削減してコードの保守性を向上
- DRY（Don't Repeat Yourself）原則に準拠

## Changes
- `CARD_COLORS`を`LABEL_COLORS`のエイリアスとして定義
- 重複した配列定義（9行）を削減
- 単一の真実の源（Single Source of Truth）を維持

## Benefits
- コードの保守性向上：色の追加・変更が1箇所で完結
- バグのリスク軽減：2つの配列の同期忘れを防止
- コードサイズの削減：9行のコードを削除

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)