### PR TITLE
chore: .gitignoreにnpm/yarnのロックファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Dependencies
 node_modules/
 
+# Lock files (pnpmプロジェクトのため、npm/yarnのロックファイルは無視)
+package-lock.json
+yarn.lock
+
 # Build
 /.cache/
 /dist/


### PR DESCRIPTION
## Summary
- .gitignoreにpackage-lock.jsonとyarn.lockを追加
- pnpmプロジェクトのため、他のパッケージマネージャーのロックファイルは管理対象外

## Changes
- `package-lock.json`を.gitignoreに追加
- `yarn.lock`を.gitignoreに追加
- コメントで理由を明記

## Why
- このプロジェクトはpnpmを使用（package.jsonのpackageManagerフィールドで指定）
- 誤ってnpmやyarnでインストールした際にロックファイルが生成されるのを防止
- pnpm-lock.yamlのみが正式な依存関係ロックファイル

## Benefits
- リポジトリの整合性を維持
- 複数のロックファイルによる混乱を防止
- CI/CDで誤ったパッケージマネージャーを使用するリスクを軽減

## Test plan
- [x] .gitignoreの構文が正しいことを確認
- [x] 既存のファイルに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)