### PR TITLE
fix: AI Auto Fixワークフローのpackage_managerをpnpmに修正

### DIFF
--- a/.github/workflows/ai-auto-fix.yml
+++ b/.github/workflows/ai-auto-fix.yml
@@ -16,7 +16,7 @@ jobs:
     uses: BoxPistols/ai-auto-fix-template/.github/workflows/reusable-ai-auto-fix.yml@main
     with:
       node_version: '20'
-      package_manager: 'npm'
+      package_manager: 'pnpm'  # pnpm@10.14.0を使用（package.json参照）
       tech_stack: 'React, TypeScript, Vite'
       language: 'ja'
     secrets:


### PR DESCRIPTION
## 変更内容
AI Auto Fixワークフローの`package_manager`設定を`npm`から`pnpm`に修正しました。

## 理由
- `package.json`で`"packageManager": "pnpm@10.14.0"`を指定している
- GitHub Actionsのワークフローも同じパッケージマネージャーを使用すべき
- npmとpnpmでは依存関係の解決方法が異なるため、一貫性が重要

## 影響範囲
- `.github/workflows/ai-auto-fix.yml`のみ
- 次回のPRからAI Auto Fixがpnpmを使用するようになる

## テスト
- typecheckは成功
- ワークフローファイルの構文は妥当

🤖 Generated with [Claude Code](https://claude.com/claude-code)