### PR TITLE
refactor: TrashModalのアクセシビリティ向上

### DIFF
--- a/src/TrashModal.tsx
+++ b/src/TrashModal.tsx
@@ -123,8 +123,16 @@ export function TrashModal({ onClose }: TrashModalProps) {
                                                 <span>削除日: {formatDeletedDate(card.deletedAt)}</span>
                                             </CardMeta>
                                             <CardActions>
-                                                <RestoreButton onClick={() => handleRestore(card)}>復元</RestoreButton>
-                                                <DeleteButton onClick={() => handlePermanentDelete(card.id)}>
+                                                <RestoreButton
+                                                    onClick={() => handleRestore(card)}
+                                                    aria-label={`${card.title || card.text}を復元`}
+                                                >
+                                                    復元
+                                                </RestoreButton>
+                                                <DeleteButton
+                                                    onClick={() => handlePermanentDelete(card.id)}
+                                                    aria-label={`${card.title || card.text}を完全に削除`}
+                                                >
                                                     完全に削除
                                                 </DeleteButton>
                                             </CardActions>
@@ -138,9 +146,14 @@ export function TrashModal({ onClose }: TrashModalProps) {
 
                 <Footer $theme={theme}>
                     {trashedCards.length > 0 && (
-                        <EmptyTrashButton onClick={handleEmptyTrash}>ゴミ箱を空にする</EmptyTrashButton>
+                        <EmptyTrashButton
+                            onClick={handleEmptyTrash}
+                            aria-label={`ゴミ箱を空にする（${trashedCards.length}件のカードを完全に削除）`}
+                        >
+                            ゴミ箱を空にする
+                        </EmptyTrashButton>
                     )}
-                    <CloseModalButton onClick={onClose} $theme={theme}>
+                    <CloseModalButton onClick={onClose} $theme={theme} aria-label='ゴミ箱を閉じる'>
                         閉じる
                     </CloseModalButton>
                 </Footer>


### PR DESCRIPTION
## 変更内容
TrashModal内の全てのボタンにaria-label属性を追加しました。

## 改善したボタン
1. **RestoreButton（復元ボタン）**
   - `aria-label`: カード名を含む（例: "タスクAを復元"）
   - スクリーンリーダーユーザーが復元対象を明確に把握できる

2. **DeleteButton（完全削除ボタン）**
   - `aria-label`: カード名を含む（例: "タスクAを完全に削除"）
   - 削除対象を明確に伝える

3. **EmptyTrashButton（ゴミ箱を空にするボタン）**
   - `aria-label`: 削除件数を含む（例: "ゴミ箱を空にする（5件のカードを完全に削除）"）
   - 影響範囲を事前に把握できる

4. **CloseModalButton（閉じるボタン）**
   - `aria-label`: "ゴミ箱を閉じる"
   - ボタンの機能を明確に伝える

## 効果
- ✅ スクリーンリーダーユーザーの操作性向上
- ✅ WCAG 2.1 Level A準拠の向上
- ✅ コンテキスト情報の明確化

## 影響範囲
- `src/TrashModal.tsx`のみ
- 既存の機能には影響なし

## テスト
- ✅ typecheck成功
- ✅ lint成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)