### PR TITLE
refactor: BoardModalのアクセシビリティ向上

### DIFF
--- a/src/BoardModal.tsx
+++ b/src/BoardModal.tsx
@@ -115,10 +115,19 @@ function SortableLabelItem({
                             }
                         />
                     </LabelColorPicker>
-                    <SaveLabelButton type='button' onClick={handleUpdateLabel}>
+                    <SaveLabelButton
+                        type='button'
+                        onClick={handleUpdateLabel}
+                        aria-label={`ラベル「${editingLabel.name}」を保存`}
+                    >
                         保存
                     </SaveLabelButton>
-                    <CancelLabelButton type='button' onClick={() => setEditingLabel(null)} $theme={theme}>
+                    <CancelLabelButton
+                        type='button'
+                        onClick={() => setEditingLabel(null)}
+                        $theme={theme}
+                        aria-label='ラベルの編集をキャンセル'
+                    >
                         キャンセル
                     </CancelLabelButton>
                 </>
@@ -126,10 +135,19 @@ function SortableLabelItem({
                 <>
                     <DragHandle title='ドラッグして並び替え'>⋮⋮</DragHandle>
                     <LabelPreview $color={label.color}>{label.name}</LabelPreview>
-                    <EditLabelButton type='button' onClick={() => setEditingLabel(label)} $theme={theme}>
+                    <EditLabelButton
+                        type='button'
+                        onClick={() => setEditingLabel(label)}
+                        $theme={theme}
+                        aria-label={`ラベル「${label.name}」を編集`}
+                    >
                         編集
                     </EditLabelButton>
-                    <DeleteLabelButton type='button' onClick={() => handleDeleteLabel(label.id)}>
+                    <DeleteLabelButton
+                        type='button'
+                        onClick={() => handleDeleteLabel(label.id)}
+                        aria-label={`ラベル「${label.name}」を削除`}
+                    >
                         削除
                     </DeleteLabelButton>
                 </>
@@ -373,10 +391,20 @@ export function BoardModal({ boardId, onClose }: BoardModalProps) {
 
                 {boardId && (
                     <TabBar $theme={theme}>
-                        <Tab $active={activeTab === 'basic'} $theme={theme} onClick={() => setActiveTab('basic')}>
+                        <Tab
+                            $active={activeTab === 'basic'}
+                            $theme={theme}
+                            onClick={() => setActiveTab('basic')}
+                            aria-label='基本情報タブ'
+                        >
                             基本情報
                         </Tab>
-                        <Tab $active={activeTab === 'labels'} $theme={theme} onClick={() => setActiveTab('labels')}>
+                        <Tab
+                            $active={activeTab === 'labels'}
+                            $theme={theme}
+                            onClick={() => setActiveTab('labels')}
+                            aria-label='ラベル管理タブ'
+                        >
                             ラベル管理
                         </Tab>
                     </TabBar>


### PR DESCRIPTION
## 変更内容
BoardModal内の全てのボタンとタブにaria-label属性を追加しました。

## 改善したボタン
1. **SaveLabelButton（保存ボタン）**
   - `aria-label`: ラベル名を含む（例: "ラベル「優先度」を保存"）
   - 保存対象を明確に把握できる

2. **CancelLabelButton（キャンセルボタン）**
   - `aria-label`: "ラベルの編集をキャンセル"
   - ボタンの機能を明確に伝える

3. **EditLabelButton（編集ボタン）**
   - `aria-label`: ラベル名を含む（例: "ラベル「優先度」を編集"）
   - 編集対象を明確に把握できる

4. **DeleteLabelButton（削除ボタン）**
   - `aria-label`: ラベル名を含む（例: "ラベル「優先度」を削除"）
   - 削除対象を明確に伝える

5. **Tab buttons（タブボタン）**
   - `aria-label`: "基本情報タブ"、"ラベル管理タブ"
   - 各タブの機能を明確に示す

## 効果
- ✅ スクリーンリーダーユーザーの操作性向上
- ✅ WCAG 2.1 Level A準拠の向上
- ✅ コンテキスト情報の明確化

## 影響範囲
- `src/BoardModal.tsx`のみ
- 既存の機能には影響なし

## テスト
- ✅ typecheck成功
- ✅ lint成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)