### PR TITLE
refactor: CardDetailModalのアクセシビリティ向上

### DIFF
--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -83,10 +83,15 @@ function SortableChecklistItem({
                         autoFocus
                         $theme={theme}
                     />
-                    <SmallButton onClick={onSaveEdit} title='保存' $theme={theme}>
+                    <SmallButton onClick={onSaveEdit} title='保存' $theme={theme} aria-label='チェックリスト項目を保存'>
                         ✓
                     </SmallButton>
-                    <SmallButton onClick={onCancelEdit} title='キャンセル' $theme={theme}>
+                    <SmallButton
+                        onClick={onCancelEdit}
+                        title='キャンセル'
+                        $theme={theme}
+                        aria-label='チェックリスト項目の編集をキャンセル'
+                    >
                         ✕
                     </SmallButton>
                 </>
@@ -101,7 +106,7 @@ function SortableChecklistItem({
                     >
                         <LinkedText text={item.text} metadata={metadata} theme={theme} />
                     </ChecklistItemText>
-                    <SmallButton onClick={onEdit} title='編集' $theme={theme}>
+                    <SmallButton onClick={onEdit} title='編集' $theme={theme} aria-label='チェックリスト項目を編集'>
                         &#9998;
                     </SmallButton>
                     <ConvertToCardButton
@@ -109,10 +114,11 @@ function SortableChecklistItem({
                         title='カードに変換'
                         $theme={theme}
                         disabled={isConverting}
+                        aria-label='チェックリスト項目をカードに変換'
                     >
                         {isConverting ? '...' : '↗'}
                     </ConvertToCardButton>
-                    <DeleteItemButton onClick={onDelete} $theme={theme}>
+                    <DeleteItemButton onClick={onDelete} $theme={theme} aria-label='チェックリスト項目を削除'>
                         ×
                     </DeleteItemButton>
                 </>
@@ -484,7 +490,11 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
                                             alt={img.name || '画像'}
                                             loading={index > 2 ? 'lazy' : 'eager'}
                                         />
-                                        <ImageRemoveButton onClick={() => handleRemoveImage(img.id)} title='画像を削除'>
+                                        <ImageRemoveButton
+                                            onClick={() => handleRemoveImage(img.id)}
+                                            title='画像を削除'
+                                            aria-label={`画像「${img.name || '画像'}」を削除`}
+                                        >
                                             ×
                                         </ImageRemoveButton>
                                     </ImageContainer>
@@ -549,7 +559,9 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
                                 placeholder='新しい項目を追加...'
                                 $theme={theme}
                             />
-                            <AddChecklistButton onClick={addChecklistItem}>追加</AddChecklistButton>
+                            <AddChecklistButton onClick={addChecklistItem} aria-label='チェックリスト項目を追加'>
+                                追加
+                            </AddChecklistButton>
                         </AddChecklistItemRow>
                     </Section>
                 </Content>


### PR DESCRIPTION
## 変更内容
CardDetailModal内の全てのチェックリスト関連ボタンと画像削除ボタンにaria-label属性を追加しました。

## 改善したボタン
1. **チェックリスト項目の保存ボタン**
   - `aria-label`: "チェックリスト項目を保存"
   - 操作内容を明確に伝える

2. **チェックリスト項目の編集キャンセルボタン**
   - `aria-label`: "チェックリスト項目の編集をキャンセル"
   - ボタンの機能を明確に伝える

3. **チェックリスト項目の編集ボタン**
   - `aria-label`: "チェックリスト項目を編集"
   - 操作内容を明確に伝える

4. **チェックリスト項目をカードに変換ボタン**
   - `aria-label`: "チェックリスト項目をカードに変換"
   - 特殊な操作内容を明確に伝える

5. **チェックリスト項目の削除ボタン**
   - `aria-label`: "チェックリスト項目を削除"
   - 操作内容を明確に伝える

6. **画像削除ボタン**
   - `aria-label`: 画像名を含む（例: "画像「screenshot.png」を削除"）
   - 削除対象を明確に把握できる

7. **チェックリスト項目追加ボタン**
   - `aria-label`: "チェックリスト項目を追加"
   - ボタンの機能を明確に伝える

## 効果
- ✅ スクリーンリーダーユーザーの操作性向上
- ✅ WCAG 2.1 Level A準拠の向上
- ✅ チェックリスト操作のアクセシビリティ改善

## 影響範囲
- `src/CardDetailModal.tsx`のみ
- 既存の機能には影響なし

## テスト
- ✅ typecheck成功
- ✅ lint成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)