### PR TITLE
refactor: Headerのモバイルメニューボタンにaria-label追加

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -149,7 +149,10 @@ export const Header = memo(function Header({ className }: { className?: string }
 
                         <MenuSection>
                             <MenuSectionTitle>設定</MenuSectionTitle>
-                            <MenuThemeToggle onClick={toggleDarkMode}>
+                            <MenuThemeToggle
+                                onClick={toggleDarkMode}
+                                aria-label={isDarkMode ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
+                            >
                                 {isDarkMode ? <SunIcon /> : <MoonIcon />}
                                 <span>{isDarkMode ? 'ライトモード' : 'ダークモード'}</span>
                             </MenuThemeToggle>
@@ -158,6 +161,7 @@ export const Header = memo(function Header({ className }: { className?: string }
                                     setIsTrashModalOpen(true)
                                     setIsMenuOpen(false)
                                 }}
+                                aria-label={`ゴミ箱${trashedCards.length > 0 ? ` (${trashedCards.length}件)` : ''}`}
                             >
                                 <TrashIcon />
                                 <span>ゴミ箱</span>
@@ -176,7 +180,9 @@ export const Header = memo(function Header({ className }: { className?: string }
                                         </UserInitial>
                                         <UserEmail>{user.email}</UserEmail>
                                     </UserInfoMobile>
-                                    <MenuLogoutButton onClick={handleLogout}>ログアウト</MenuLogoutButton>
+                                    <MenuLogoutButton onClick={handleLogout} aria-label='ログアウト'>
+                                        ログアウト
+                                    </MenuLogoutButton>
                                 </MenuSection>
                             </>
                         )}


### PR DESCRIPTION
## 変更内容
Headerのモバイルメニュー内の全てのボタンにaria-label属性を追加しました。

## 改善したボタン
1. **MenuThemeToggle（テーマ切り替えボタン）**
   - `aria-label`: 現在の状態に応じたラベル（"ライトモードに切り替え" / "ダークモードに切り替え"）
   - デスクトップ版と同等のアクセシビリティを確保

2. **MenuTrashButton（ゴミ箱ボタン）**
   - `aria-label`: アイテム数を含むラベル（例: "ゴミ箱 (5件)"）
   - ゴミ箱の状態を明確に伝える

3. **MenuLogoutButton（ログアウトボタン）**
   - `aria-label`: "ログアウト"
   - ボタンの機能を明確に伝える

## 背景
デスクトップ版のボタンにはすでにaria-label属性が設定されていましたが、モバイルメニュー内のボタンには設定されていませんでした。この変更により、モバイルユーザーもデスクトップユーザーと同等のアクセシビリティを享受できます。

## 効果
- ✅ モバイルユーザーのアクセシビリティ向上
- ✅ スクリーンリーダーユーザーの操作性向上
- ✅ WCAG 2.1 Level A準拠の向上

## 影響範囲
- `src/Header.tsx`のみ
- 既存の機能には影響なし

## テスト
- ✅ typecheck成功
- ✅ lint成功
- ✅ build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)