### PR TITLE
fix: React hooks order violation causing app crash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,28 +180,7 @@ export function App() {
         return () => document.removeEventListener('keydown', handleKeyDown)
     }, [])
 
-    // Show loading while checking auth
-    if (isFirebaseEnabled && !isInitialized && !offlineMode) {
-        return (
-            <>
-                <GlobalStyle $theme={theme} />
-                <LoadingContainer $theme={theme}>
-                    <LoadingText $theme={theme}>読み込み中...</LoadingText>
-                </LoadingContainer>
-            </>
-        )
-    }
-
-    // Show auth screen if Firebase is enabled and user is not authenticated and not in offline mode
-    if (isFirebaseEnabled && !user && !offlineMode) {
-        return (
-            <>
-                <GlobalStyle $theme={theme} />
-                <Auth onSkipAuth={() => setOfflineMode(true)} />
-            </>
-        )
-    }
-
+    // All useCallback hooks must be called before conditional returns
     const handleDragStart = useCallback((event: DragStartEvent) => {
         setActiveId(event.active.id as string)
     }, [])
@@ -319,6 +298,28 @@ export function App() {
     }, [])
 
     const activeCard = activeId ? cards.find((c) => c.id === activeId) : null
+
+    // Show loading while checking auth
+    if (isFirebaseEnabled && !isInitialized && !offlineMode) {
+        return (
+            <>
+                <GlobalStyle $theme={theme} />
+                <LoadingContainer $theme={theme}>
+                    <LoadingText $theme={theme}>読み込み中...</LoadingText>
+                </LoadingContainer>
+            </>
+        )
+    }
+
+    // Show auth screen if Firebase is enabled and user is not authenticated and not in offline mode
+    if (isFirebaseEnabled && !user && !offlineMode) {
+        return (
+            <>
+                <GlobalStyle $theme={theme} />
+                <Auth onSkipAuth={() => setOfflineMode(true)} />
+            </>
+        )
+    }
 
     return (
         <ErrorBoundary>


### PR DESCRIPTION
## Summary
- Reactのhooksの順序違反を修正し、アプリのクラッシュを解消

## Problem
- useCallback hooksが条件付き早期リターンの後に呼ばれていた（App.tsx:205行目）
- エラー: "Rendered more hooks than during the previous render"
- ReactのRules of Hooksに違反していた

## Solution
- すべてのuseCallback hooksを条件付きリターンの前に移動
- handleDragStart, handleDragEnd, toggleColumnCollapse, handleHardReloadを183行目以降に配置
- activeCardの計算も早期リターンの前に移動
- hooks順序の要件を明確にするコメントを追加

## Test plan
- [x] TypeScript型チェック通過
- [x] ESLint検証通過
- [x] プロダクションビルド成功
- [ ] 開発環境でアプリが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)