### PR TITLE
fix: pnpm version mismatch in GitHub Actions

### DIFF
--- a/.github/workflows/ai-auto-fix.yml
+++ b/.github/workflows/ai-auto-fix.yml
@@ -16,7 +16,8 @@ jobs:
     uses: BoxPistols/ai-auto-fix-template/.github/workflows/reusable-ai-auto-fix.yml@main
     with:
       node_version: '20'
-      package_manager: 'pnpm'  # pnpm@10.14.0を使用（package.json参照）
+      package_manager: 'pnpm'
+      pnpm_version: '10.14.0'  # package.jsonと一致させる
       tech_stack: 'React, TypeScript, Vite'
       language: 'ja'
     secrets:


### PR DESCRIPTION
## Summary
- GitHub Actionsでのpnpmバージョン不一致エラーを修正

## Problem
- `ai-auto-fix.yml` がデフォルトのpnpm version 9を使用
- `package.json` では pnpm@10.14.0 を指定
- バージョン不一致により `ERR_PNPM_BAD_PM_VERSION` エラーが発生

## Solution
- `ai-auto-fix.yml` に `pnpm_version: '10.14.0'` パラメータを追加
- `package.json` の `packageManager` フィールドと一致させる

## Test plan
- [x] ワークフローファイルの構文確認
- [ ] 次のPRでCI が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)