### PR TITLE
feat: モーダルにフォーカストラップを実装してアクセシビリティを改善

### DIFF
--- a/src/BaseModal.tsx
+++ b/src/BaseModal.tsx
@@ -31,13 +31,55 @@ export const BaseModal = memo(function BaseModal({
     const theme = getTheme(isDarkMode)
     const modalRef = useRef<HTMLDivElement>(null)
 
-    // フォーカス管理: モーダル内の最初のフォーカス可能要素にフォーカス
+    // フォーカス管理: モーダル内の最初のフォーカス可能要素にフォーカス + フォーカストラップ
     useEffect(() => {
-        const focusableElements = modalRef.current?.querySelectorAll(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        )
-        const firstElement = focusableElements?.[0] as HTMLElement
+        const modal = modalRef.current
+        if (!modal) return
+
+        const getFocusableElements = () => {
+            return Array.from(
+                modal.querySelectorAll<HTMLElement>(
+                    'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+                )
+            )
+        }
+
+        // 最初の要素にフォーカス
+        const focusableElements = getFocusableElements()
+        const firstElement = focusableElements[0]
         firstElement?.focus()
+
+        // フォーカストラップ: Tabキーでモーダル内をループ
+        const handleTab = (e: KeyboardEvent) => {
+            if (e.key !== 'Tab') return
+
+            const focusableElements = getFocusableElements()
+            if (focusableElements.length === 0) return
+
+            const firstElement = focusableElements[0]
+            const lastElement = focusableElements[focusableElements.length - 1]
+            const activeElement = document.activeElement as HTMLElement
+
+            if (e.shiftKey) {
+                // Shift+Tab: 逆方向
+                if (activeElement === firstElement) {
+                    e.preventDefault()
+                    lastElement?.focus()
+                }
+            } else {
+                // Tab: 順方向
+                if (activeElement === lastElement) {
+                    e.preventDefault()
+                    firstElement?.focus()
+                }
+            }
+        }
+
+        document.addEventListener('keydown', handleTab)
+
+        return () => {
+            document.removeEventListener('keydown', handleTab)
+        }
     }, [])
 
     // Escapeキーでモーダルを閉じる & bodyクラスでスクロールを無効化


### PR DESCRIPTION
## Summary
- モーダルのアクセシビリティを改善するフォーカストラップ機能を実装

## Problem
- 現在: モーダル内でTabキーを押すと、フォーカスがモーダル外の要素に移動してしまう
- ユーザーがモーダル内のコンテンツから離れてしまい、操作が困難
- WCAG 2.1 AA基準のアクセシビリティ要件を満たしていない

## Solution
- **フォーカストラップ**を実装
  - Tab: 最後の要素に到達したら最初の要素にループ
  - Shift+Tab: 最初の要素に到達したら最後の要素にループ
  - 無効化された要素（disabled）はスキップ
  - フォーカス可能要素を動的に取得（DOM変更に対応）

## Technical Details
- `keydown`イベントをリッスンしてTabキーを検出
- `document.activeElement`で現在のフォーカス要素を追跡
- `preventDefault()`でデフォルトのタブ動作を無効化してカスタム動作を実装

## Accessibility Impact
- **WCAG 2.1 AA準拠**: フォーカス管理の要件を満たす
- **キーボード操作性向上**: マウスなしでもモーダル操作が快適に
- **スクリーンリーダー対応**: フォーカスの流れが明確に

## Test plan
- [x] TypeScript型チェック通過
- [x] ESLint検証通過
- [x] プロダクションビルド成功
- [ ] 手動テスト: モーダル内でTabキーを押して最初/最後の要素でループすることを確認
- [ ] 手動テスト: Shift+Tabで逆方向にループすることを確認
- [ ] 手動テスト: 無効化されたボタンがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)