### PR TITLE
perf: モーダルコンポーネントをmemo化してパフォーマンスを改善

### DIFF
--- a/src/BoardModal.tsx
+++ b/src/BoardModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, memo } from 'react'
 import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core'
@@ -156,7 +156,7 @@ function SortableLabelItem({
     )
 }
 
-export function BoardModal({ boardId, onClose }: BoardModalProps) {
+export const BoardModal = memo(function BoardModal({ boardId, onClose }: BoardModalProps) {
     const { boards, updateBoard, addBoard, deleteBoard, addLabelToBoard, removeLabelFromBoard, updateLabel } =
         useBoardStore()
     const { isDarkMode } = useThemeStore()
@@ -573,7 +573,7 @@ export function BoardModal({ boardId, onClose }: BoardModalProps) {
             </ModalContent>
         </BaseModal>
     )
-}
+}) // memo
 
 const ModalContent = styled.div<{ $theme: Theme }>`
     display: flex;

--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, memo } from 'react'
 import styled from 'styled-components'
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
@@ -127,7 +127,7 @@ function SortableChecklistItem({
     )
 }
 
-export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
+export const CardDetailModal = memo(function CardDetailModal({ card, onClose }: CardDetailModalProps) {
     const { updateCard, addCard } = useKanbanStore()
     const { boards, currentBoardId } = useBoardStore()
     const { isDarkMode } = useThemeStore()
@@ -588,7 +588,7 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
             </ModalContent>
         </BaseModal>
     )
-}
+}) // memo
 
 const ModalContent = styled.div<{ $theme: Theme }>`
     display: flex;

--- a/src/ColumnManager.tsx
+++ b/src/ColumnManager.tsx
@@ -163,7 +163,7 @@ interface ColumnManagerProps {
     onClose: () => void
 }
 
-export function ColumnManager({ boardId, onClose }: ColumnManagerProps) {
+export const ColumnManager = memo(function ColumnManager({ boardId, onClose }: ColumnManagerProps) {
     const { getColumns, addColumn, removeColumn, updateColumn, reorderColumns } = useBoardStore()
     const { isDarkMode } = useThemeStore()
     const theme = getTheme(isDarkMode)
@@ -276,7 +276,7 @@ export function ColumnManager({ boardId, onClose }: ColumnManagerProps) {
             </ModalContent>
         </BaseModal>
     )
-}
+}) // memo
 
 const ModalContent = styled.div<{ $theme: Theme }>`
     display: flex;

--- a/src/TrashModal.tsx
+++ b/src/TrashModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, memo } from 'react'
 import styled from 'styled-components'
 import * as color from './color'
 import { useTrashStore, TrashedCard } from './store/trashStore'
@@ -13,7 +13,7 @@ interface TrashModalProps {
     onClose: () => void
 }
 
-export function TrashModal({ onClose }: TrashModalProps) {
+export const TrashModal = memo(function TrashModal({ onClose }: TrashModalProps) {
     const { trashedCards, restoreFromTrash, permanentlyDelete, emptyTrash, loadTrash, getDaysUntilPermanentDeletion } =
         useTrashStore()
     const { restoreCard } = useKanbanStore()
@@ -160,7 +160,7 @@ export function TrashModal({ onClose }: TrashModalProps) {
             </ModalContent>
         </BaseModal>
     )
-}
+}) // memo
 
 const ModalContent = styled.div<{ $theme: Theme }>`
     display: flex;


### PR DESCRIPTION
## Summary
- ColumnManager, BoardModal, CardDetailModal, TrashModal の4つのモーダルコンポーネントを `React.memo` でラップ
- 親コンポーネントの更新時に不要な再レンダリングを防止し、パフォーマンスを改善

## Test plan
- [x] TypeScript型チェック通過
- [x] ESLint警告なし
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * モーダル関連の画面表示を最適化し、不要な再描画を減らしました。
  * ボード管理、カード詳細、列管理、ゴミ箱の各モーダルで、操作時の動作がより滑らかになる場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->