### PR TITLE
fix: 本番白画面を修正（@dnd-kitとReact/ReactDOMを同一チャンクに）

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,8 +72,22 @@ export default defineConfig({
       output: {
         manualChunks: {
           firebase: ['firebase/app', 'firebase/firestore', 'firebase/auth'],
-          dndkit: ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
-          vendor: ['react', 'react-dom', 'zustand', 'styled-components'],
+          // Keep React, ReactDOM and React-internals-dependent libs (@dnd-kit)
+          // in ONE chunk. Splitting @dnd-kit into its own chunk caused a
+          // production-only crash: @dnd-kit reads
+          // ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+          // (unstable_batchedUpdates) at module-eval time and got `undefined`
+          // when react-dom lived in a separate chunk (init-order/circular),
+          // throwing before render → white screen.
+          vendor: [
+            'react',
+            'react-dom',
+            '@dnd-kit/core',
+            '@dnd-kit/sortable',
+            '@dnd-kit/utilities',
+            'zustand',
+            'styled-components',
+          ],
         }
       }
     }


### PR DESCRIPTION
## 概要（本番ダウンの hotfix）
本番（kanban-relax.netlify.app）が**白画面**。コンソール:
```
Uncaught TypeError: Cannot read properties of undefined
(reading '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED')  @ dndkit-*.js
```

## 原因
`vite.config.ts` の `manualChunks` が **@dnd-kit を react-dom と別チャンク**に分離していた:
```
dndkit: ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
vendor: ['react', 'react-dom', ...],
```
`@dnd-kit` はモジュール評価時に `ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`（`unstable_batchedUpdates`）を参照する。別チャンク化によりロード順/循環初期化で **react-dom が `undefined`** になり、レンダー前に throw → 白画面（本番のみ／dev は単一バンドルなので再現せず）。React は 18.3.1 で、19 の内部削除とは無関係。

## 修正
`@dnd-kit/*` を **vendor チャンク（react/react-dom と同居）に統合**し、独立 `dndkit` チャンクを廃止。React 内部に依存するライブラリを React と同一チャンクに置くのが定石。

## 検証
- `npm run build` 成功 → **`dndkit-*.js` チャンクが消滅**
- `vendor-*.js` に **react-dom 内部(`__SECRET_INTERNALS`)と @dnd-kit が同居**することを grep で確認

マージ → Netlify 再デプロイで本番復旧の見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)