### PR TITLE
fix: クラウドデータ同期不能を修正(監査 C3 認証前購読 / C4 複合インデックス未デプロイ)

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Firebase Rules
+name: Deploy Firestore Rules & Indexes
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/firebase-deploy.yml'
 
 jobs:
-  deploy-firestore-rules:
+  deploy-firestore:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,7 +24,10 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Deploy Firestore Rules
+      - name: Deploy Firestore Rules & Indexes
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        run: firebase deploy --only firestore:rules --token "$FIREBASE_TOKEN"
+        # rules だけでなく indexes も deploy。アプリの本番クエリ
+        # (boards: userId+createdAt / cards: userId+order) は複合インデックス必須で、
+        # 未デプロイだと onSnapshot がインデックスエラーを投げオフラインに落ちる(監査C4)。
+        run: firebase deploy --only firestore:rules,firestore:indexes --token "$FIREBASE_TOKEN"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,34 @@
 {
   "indexes": [
     {
+      "collectionGroup": "boards",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "cards",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "order",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "cards",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,16 +122,25 @@ export function App() {
         initAuth()
     }, [initAuth])
 
+    // Firebase有効時は認証が解決(isInitialized && user)するまで購読を待つ。
+    // 解決前に購読すると userId 未確定のクエリがセキュリティルールで拒否され、
+    // 以降 deps が変化せず再購読されないためクラウドデータが永久に空になる(監査C3)。
+    // userId を deps に含め、サインイン/ユーザー切替時に正しく再購読させる。
+    const userId = user?.uid
+    const firebaseAuthPending = isFirebaseEnabled && !offlineMode && (!isInitialized || !userId)
+
     useEffect(() => {
+        if (firebaseAuthPending) return
         const unsubscribeBoards = subscribeToBoards()
         return () => unsubscribeBoards()
-    }, [subscribeToBoards])
+    }, [subscribeToBoards, firebaseAuthPending, userId])
 
     useEffect(() => {
         if (!currentBoardId) return
+        if (firebaseAuthPending) return
         const unsubscribeCards = subscribeToCards(currentBoardId)
         return () => unsubscribeCards()
-    }, [subscribeToCards, currentBoardId])
+    }, [subscribeToCards, currentBoardId, firebaseAuthPending, userId])
 
     // 折りたたみ状態の復元
     // localStorageとの同期は外部システムとの連携なので、useEffect内のsetStateは適切


### PR DESCRIPTION
## 背景

監査(C3/C4)で見つかった **クラウドデータが本番で読み込まれない HIGH 級の同期バグ**を2件まとめて修正。両者は同時に直さないと意味がない（C3を直してもインデックスが無ければクエリが失敗する）ため1 PRに。

## C3 — 認証解決前に Firestore を購読してしまう

`App.tsx` の購読 effect が deps `[subscribeToBoards]`（安定参照）のみで **mount時1回だけ**発火していた。`initAuth()` 直後で `user` 未確定のため `userId` が `undefined` の状態でクエリを発行 → セキュリティルール(`request.auth`/`resource.data.userId`)で拒否 → onSnapshot エラーで **オフラインモードへフォールバック**。その後 deps が変化しないため認証完了後も**再購読されず、クラウドデータが永久に空**になっていた。

**修正:** `isFirebaseEnabled && !offlineMode && (!isInitialized || !userId)` の間は購読を保留し、`userId` を deps に追加。サインイン完了・ユーザー切替で正しく再購読する。オフライン/Firebase未設定時は従来どおり即購読（スモークテストで確認済み）。

## C4 — 本番クエリに必要な複合インデックスが不在 & CI が一度も deploy していない

実際に走るクエリ:
- `boards`: `where(userId ==) + orderBy(createdAt)` → 複合インデックス必須
- `cards`: `where(userId ==) + orderBy(order)` → 複合インデックス必須

どちらも `firestore.indexes.json` に無く（あったのは `boardId+order` / `columnId+order` のみ）、さらに `firebase-deploy.yml` は `--only firestore:rules` で **indexes を一度も反映していなかった**。C3を直してもこのままではクエリが "needs index" で失敗しオフラインに落ちる。

**修正:**
- `boards: userId+createdAt`, `cards: userId+order` の2インデックスを追加
- deploy対象を `firestore:rules,firestore:indexes` に拡張（パスフィルタは既に indexes 変更で発火する設定）

## 検証
- `pnpm typecheck` ✅
- `pnpm test:e2e`（スモーク: 白画面/pageerror検出）✅
- indexes JSON 妥当性 ✅

## 監査の残タスク（本PRには含めない）
C5(ルール強化) / C6(manifest重複) / C7(フィルタ中ドラッグ) / C8(debug出力) / C9(audit fix) / C12(netlify secrets scan) は次PRで。要判断4件(firebase major / trash再設計 / lockfile統合 / service account化)はADR・報告に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)