### PR TITLE
fix: 監査MED 4件(C6 manifest重複/404 · C7 フィルタ中ドラッグ破壊 · C8 debug出力 · C12 secrets scan)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
   command = "npm run build"
   publish = "dist"
 
-# Firebase設定は公開情報なのでスキャンから除外
+# Firebase のクライアント設定キーは公開前提でバンドルに載るため除外する。
+# ただしスキャン自体は有効のままにし、他の秘密の混入は引き続き検出する(監査C12)。
 [build.environment]
-  SECRETS_SCAN_ENABLED = "false"
+  SECRETS_SCAN_OMIT_KEYS = "VITE_FIREBASE_API_KEY,VITE_FIREBASE_AUTH_DOMAIN,VITE_FIREBASE_PROJECT_ID,VITE_FIREBASE_STORAGE_BUCKET,VITE_FIREBASE_MESSAGING_SENDER_ID,VITE_FIREBASE_APP_ID"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,8 +27,14 @@ import { BoardIcon } from './icon'
 import { getTheme, Theme } from './theme'
 import { isFirebaseEnabled } from './lib/firebase'
 import { isShortcutKey } from './utils/keyboard'
-import './utils/debugFirestore' // デバッグユーティリティ（コンソールで window.debugFirestore() を実行）
 import type { Card as CardType, ColumnType } from './types'
+
+// Firestore デバッグユーティリティ(window.debugFirestore)は開発時のみロードする。
+// 本番に同梱すると全ユーザーのカードをコンソールにダンプし得るため(監査C8)。
+// import.meta.env.DEV は本番ビルドで false に畳まれ、この動的importごと除去される。
+if (import.meta.env.DEV) {
+    void import('./utils/debugFirestore')
+}
 
 // 遅延ロード: モーダル系コンポーネント
 const ColumnManager = lazy(() => import('./ColumnManager').then((m) => ({ default: m.ColumnManager })))
@@ -99,6 +105,9 @@ export function App() {
 
         return filtered
     }, [cards, searchQuery, selectedLabelIds])
+
+    // 検索/ラベルでフィルタ中か。フィルタ中はドラッグ並べ替えを抑止する(C7)。
+    const isFiltered = searchQuery.trim() !== '' || selectedLabelIds.length > 0
 
     const cardsByColumn = useMemo(() => {
         const grouped = filteredCards.reduce<Record<ColumnType, CardType[]>>(
@@ -203,6 +212,10 @@ export function App() {
             const { active, over } = event
             setActiveId(null)
 
+            // フィルタ適用中の並べ替えは表示中カードだけで order を再採番し、
+            // 非表示カードの order を破壊する(監査C7)。フィルタ中は抑止する。
+            if (isFiltered) return
+
             if (!over) return
 
             const activeId = active.id as string
@@ -277,7 +290,7 @@ export function App() {
                 }
             }
         },
-        [cards, columns, cardsByColumn, reorderCards]
+        [cards, columns, cardsByColumn, reorderCards, isFiltered]
     )
 
     const toggleColumnCollapse = useCallback(

--- a/src/utils/debugFirestore.ts
+++ b/src/utils/debugFirestore.ts
@@ -85,7 +85,7 @@ export async function debugFirestore() {
     console.groupEnd()
 }
 
-// グローバルに登録
-if (typeof window !== 'undefined') {
+// グローバルに登録（開発時のみ。本番では全カードをダンプし得るため公開しない: 監査C8）
+if (typeof window !== 'undefined' && import.meta.env.DEV) {
     ;(window as { debugFirestore?: () => Promise<void> }).debugFirestore = debugFirestore
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,27 +7,11 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
-      manifest: {
-        name: 'Kanban Board',
-        short_name: 'Kanban',
-        description: 'カンバンボードアプリケーション - React + Firebase',
-        theme_color: '#1a1a2e',
-        background_color: '#1a1a2e',
-        display: 'standalone',
-        icons: [
-          {
-            src: '/icon-192.png',
-            sizes: '192x192',
-            type: 'image/png',
-          },
-          {
-            src: '/icon-512.png',
-            sizes: '512x512',
-            type: 'image/png',
-          },
-        ],
-      },
+      // Web manifest は public/manifest.json を単一ソースとして使う(index.html が参照)。
+      // VitePWA に manifest を生成させると 2 つ目の <link rel="manifest"> が注入されて
+      // 重複し、さらに存在しない icon-192/512.png を参照して 404 になっていた(監査C6)。
+      manifest: false,
+      includeAssets: ['robots.txt', 'apple-touch-icon.png', 'favicon.svg', 'manifest.json'],
       workbox: {
         cleanupOutdatedCaches: true,
         // NOTE: skipWaiting / clientsClaim を有効にすると、デプロイ中に新SWが


### PR DESCRIPTION
監査の MED 級うち、**クライアント側/CI設定のみで本番データ無影響**の4件をまとめて修正。

## C6 — manifest 重複 & 404 アイコン
VitePWA の `manifest:` 設定が独自 manifest を生成し、ビルド HTML に **2つ目の `<link rel="manifest">`** を注入。さらに存在しない `icon-192/512.png` を参照して 404。`manifest: false` にして `public/manifest.json`(実在アイコン参照)を単一ソース化。`includeAssets` も実在ファイルに修正。
- build 後 `dist/index.html` の manifest link = **1**、`icon-192/512` 参照 = **0**、`*.webmanifest` 生成 = **0** を確認。

## C7 — フィルタ中ドラッグで非表示カードの order 破壊
`handleDragEnd` は `cardsByColumn`(= `filteredCards` 由来)で order を 0..N 再採番する。検索/ラベルフィルタ中は表示中カードしか含まれず、非表示カードの order を破壊する。フィルタ中は並べ替えを抑止(early return)。

## C8 — デバッグ出力が本番同梱
`window.debugFirestore`(全ユーザーのカードをコンソールにダンプし得る)が無条件 import で本番に同梱されていた。`import.meta.env.DEV` ガード下の動的 import に変更し、登録側にも DEV ガードを追加。
- prod バンドルから完全除去を build で確認(`debugFirestore` 参照 = 0)。

## C12 — Netlify secrets scan 全無効化
`SECRETS_SCAN_ENABLED="false"`(全スキャン無効)を `SECRETS_SCAN_OMIT_KEYS`(Firebase クライアントキー6種のみ除外)に変更。他の秘密混入は引き続き検出。
- ※ この設定は PR の deploy-preview スキャンで検証される。

## 検証
- `pnpm typecheck` ✅ / `pnpm build` ✅ / `pnpm test:e2e`(スモーク)✅

## このPRに含めないもの(意図的)
- **C5**(firestore.rules の fail-open 撤去): merge で**本番ルールが自動デプロイ**され、レガシーな userId 無し文書を消失させ得るため**別PRに分離してレビュー依頼**。
- **C9**(audit): 主因は firebase SDK の transitive 脆弱性(undici 等、ブラウザ非経路)。`pnpm.overrides` 強制は runtime 破壊リスクがあるため firebase メジャーアップグレード ADR に集約。

🤖 Generated with [Claude Code](https://claude.com/claude-code)