### PR TITLE
fix: Firestoreルール fail-open 撤去 + 所有権固定(監査C5) ⚠️要レビュー・本番自動デプロイ

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,28 +3,34 @@ service cloud.firestore {
   match /databases/{database}/documents {
     // カードコレクション: 自分が作成したカードのみアクセス可能
     match /cards/{cardId} {
-      allow read: if request.auth != null &&
-                     (resource.data.userId == request.auth.uid || !('userId' in resource.data));
+      // read は所有者のみ。以前は `!('userId' in resource.data)` を OR で許可しており
+      // userId 欠落ドキュメントを任意の認証ユーザーが読める fail-open だった(監査C5)。
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
       allow create: if request.auth != null &&
                        request.resource.data.userId == request.auth.uid;
-      allow update, delete: if request.auth != null &&
-                              resource.data.userId == request.auth.uid;
+      // update は所有者のみ。さらに userId の付け替え(所有権移転)を禁止する。
+      allow update: if request.auth != null &&
+                       resource.data.userId == request.auth.uid &&
+                       request.resource.data.userId == request.auth.uid;
+      allow delete: if request.auth != null &&
+                       resource.data.userId == request.auth.uid;
     }
 
     // ボードコレクション: 自分が作成したボードのみアクセス可能
     match /boards/{boardId} {
-      allow read: if request.auth != null &&
-                     (resource.data.userId == request.auth.uid || !('userId' in resource.data));
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
       allow create: if request.auth != null &&
                        request.resource.data.userId == request.auth.uid;
-      allow update, delete: if request.auth != null &&
-                              resource.data.userId == request.auth.uid;
+      allow update: if request.auth != null &&
+                       resource.data.userId == request.auth.uid &&
+                       request.resource.data.userId == request.auth.uid;
+      allow delete: if request.auth != null &&
+                       resource.data.userId == request.auth.uid;
     }
 
     // ゴミ箱コレクション: 自分が削除したカードのみアクセス可能
     match /trash/{trashId} {
-      allow read: if request.auth != null &&
-                     (resource.data.userId == request.auth.uid || !('userId' in resource.data));
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
       allow create: if request.auth != null &&
                        request.resource.data.userId == request.auth.uid;
       allow delete: if request.auth != null &&


### PR DESCRIPTION
> ⚠️ **このPRは自動マージしません。** merge すると `firebase-deploy` ワークフローが**本番の Firestore ルールを自動デプロイ**します。レビューと下記確認のうえ、明示的に merge してください。

## 何を直すか
監査C5。`firestore.rules` の read 条件にあった fail-open を撤去し、update を所有権固定にする。

### Before(fail-open)
```
allow read: if request.auth != null &&
   (resource.data.userId == request.auth.uid || !('userId' in resource.data));
```
`!('userId' in resource.data)` により、**userId フィールドを持たないドキュメントは任意の認証ユーザーが読める**状態だった(cards / boards / trash すべて)。

### After
- `read`: 所有者(`resource.data.userId == uid`)のみ。
- `update`: 所有者チェックに加え `request.resource.data.userId == uid` を要求し、**userId の付け替え(所有権移転)を禁止**。
- `create` / `delete` は従来どおり。

## 互換性の確認
現行クライアントの書き込みは `addDoc`(userId 付きで作成)と `updateDoc`(部分更新で userId 保持)のみ。`setDoc` による全置換は存在しないため、`request.resource.data.userId` は常に既存の userId を保ち、**正当な更新はブロックされない**ことをコード確認済み。

## ⚠️ merge 前に確認してほしいこと
fail-open を外すと、**userId フィールドを持たないレガシー文書は読めなくなる**。`create` ルールは常に userId を要求してきたため理論上は存在しないはずだが、fail-open が**かつて追加された経緯**から、初期データに userId 無し文書が残っている可能性がある。

- 推奨: 本番 Firestore に userId 無しの cards/boards/trash 文書が無いことを確認(または userId バックフィル)してから merge。
- 万一読めなくなった場合は、このルールを revert すれば即時復旧可能(再デプロイ)。

## このPRに含めないもの
クライアント挙動の変更なし(ルールのみ)。CI(verify/スモーク)はルールに非依存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)