### PR TITLE
test: コンポーネントテスト追加(LinkedText / ChunkErrorBoundary) — ADR Phase1

### DIFF
--- a/src/ChunkErrorBoundary.test.tsx
+++ b/src/ChunkErrorBoundary.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChunkErrorBoundary, clearChunkReloadFlag } from './ChunkErrorBoundary'
+
+const RELOAD_FLAG = 'kanban-chunk-reload-attempted'
+
+// 描画時に投げるだけのコンポーネント
+function Bomb({ error }: { error: Error }): never {
+    throw error
+}
+
+describe('ChunkErrorBoundary', () => {
+    let reloadMock: ReturnType<typeof vi.fn>
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+    const originalLocation = window.location
+
+    beforeEach(() => {
+        sessionStorage.clear()
+        reloadMock = vi.fn()
+        // jsdom では location.reload が non-configurable なので、location ごと差し替える。
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { href: originalLocation.href, reload: reloadMock },
+        })
+        // エラーバウンダリが捕捉した例外の console.error ノイズを抑止
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: originalLocation,
+        })
+        consoleErrorSpy.mockRestore()
+    })
+
+    it('エラーが無ければ子要素をそのまま描画する', () => {
+        render(
+            <ChunkErrorBoundary>
+                <div>正常な子要素</div>
+            </ChunkErrorBoundary>
+        )
+        expect(screen.getByText('正常な子要素')).toBeInTheDocument()
+    })
+
+    it('ChunkLoadError を捕捉したら一度だけリロードしフラグを立てる', () => {
+        render(
+            <ChunkErrorBoundary>
+                <Bomb error={new Error('Loading chunk 42 failed')} />
+            </ChunkErrorBoundary>
+        )
+        expect(reloadMock).toHaveBeenCalledTimes(1)
+        expect(sessionStorage.getItem(RELOAD_FLAG)).toBe('1')
+    })
+
+    it('既にリロード済みフラグがあれば再リロードしない（ループ防止）', () => {
+        sessionStorage.setItem(RELOAD_FLAG, '1')
+        render(
+            <ChunkErrorBoundary>
+                <Bomb error={new Error('Failed to fetch dynamically imported module')} />
+            </ChunkErrorBoundary>
+        )
+        expect(reloadMock).not.toHaveBeenCalled()
+    })
+
+    it('チャンク系でない通常エラーではリロードせず何も描画しない', () => {
+        const { container } = render(
+            <ChunkErrorBoundary>
+                <Bomb error={new Error('ただのレンダリングエラー')} />
+            </ChunkErrorBoundary>
+        )
+        expect(reloadMock).not.toHaveBeenCalled()
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('clearChunkReloadFlag はリロード済みフラグを消す', () => {
+        sessionStorage.setItem(RELOAD_FLAG, '1')
+        clearChunkReloadFlag()
+        expect(sessionStorage.getItem(RELOAD_FLAG)).toBeNull()
+    })
+})

--- a/src/LinkedText.test.tsx
+++ b/src/LinkedText.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LinkedText } from './LinkedText'
+import { getTheme } from './theme'
+import type { UrlMetadata } from './types'
+
+const theme = getTheme(false)
+
+describe('LinkedText', () => {
+    it('URL を含まないテキストはリンク化せずそのまま表示する', () => {
+        const { container } = render(<LinkedText text='ただのテキスト' theme={theme} />)
+        expect(container.querySelectorAll('a')).toHaveLength(0)
+        expect(container.textContent).toBe('ただのテキスト')
+    })
+
+    it('単一の URL をアンカーに変換し href とテキストに URL を使う', () => {
+        render(<LinkedText text='see https://example.com now' theme={theme} />)
+        const link = screen.getByRole('link')
+        expect(link).toHaveAttribute('href', 'https://example.com')
+        expect(link).toHaveTextContent('https://example.com')
+    })
+
+    it('リンクは新しいタブで開き安全な rel を付与する', () => {
+        render(<LinkedText text='https://example.com' theme={theme} />)
+        const link = screen.getByRole('link')
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('メタデータの title を表示文言に使いつつ href には URL を保つ', () => {
+        const metadata: UrlMetadata[] = [{ url: 'https://example.com', title: 'Example Site', fetchedAt: 0 }]
+        render(<LinkedText text='https://example.com' metadata={metadata} theme={theme} />)
+        const link = screen.getByRole('link')
+        expect(link).toHaveTextContent('Example Site')
+        expect(link).toHaveAttribute('href', 'https://example.com')
+        // title 属性は常に生 URL（ホバーで実体を確認できる）
+        expect(link).toHaveAttribute('title', 'https://example.com')
+    })
+
+    it('リンク前後のプレーンテキストを保持する', () => {
+        const { container } = render(<LinkedText text='before https://example.com after' theme={theme} />)
+        expect(container.textContent).toBe('before https://example.com after')
+        expect(screen.getAllByRole('link')).toHaveLength(1)
+    })
+
+    it('複数の URL を出現順にリンク化する', () => {
+        render(<LinkedText text='https://a.example.com and https://b.example.com' theme={theme} />)
+        const links = screen.getAllByRole('link')
+        expect(links).toHaveLength(2)
+        expect(links[0]).toHaveAttribute('href', 'https://a.example.com')
+        expect(links[1]).toHaveAttribute('href', 'https://b.example.com')
+    })
+
+    it('末尾の ASCII 句読点はリンクに含めない', () => {
+        render(<LinkedText text='詳細は https://example.com. 続きを読む' theme={theme} />)
+        const link = screen.getByRole('link')
+        expect(link).toHaveAttribute('href', 'https://example.com')
+    })
+
+    it('新しいタブで開くことを示すアクセシブルなラベルを付与する', () => {
+        render(<LinkedText text='https://example.com' theme={theme} />)
+        const link = screen.getByRole('link')
+        expect(link.getAttribute('aria-label')).toContain('新しいタブで開く')
+    })
+})


### PR DESCRIPTION
ADR-001 の Phase1「コンポーネントテスト整備」の着手。依存メジャーアップグレード前にリグレッション検出網を広げる目的。安全側の**自己完結コンポーネント**から開始。

## 追加テスト（13件 / 全体 50→63）
### LinkedText (8)
- URL 無しはリンク化せず素のテキスト
- 単一 URL を href=URL のアンカーに変換
- `target=_blank` + `rel=noopener noreferrer`
- メタデータ `title` を表示文言に使いつつ href は生 URL を保持
- リンク前後のプレーンテキスト保持 / 複数 URL を順序保持
- 末尾 ASCII 句読点をリンクに含めない（#82 の挙動を固定化）
- 「新しいタブで開く」aria-label

### ChunkErrorBoundary (5) — 白画面再発防止ロジックの固定化
- 正常時は子要素を描画
- ChunkLoadError 捕捉で **1 回だけ** reload + sessionStorage フラグ
- フラグ既存なら再 reload しない（リロードループ防止）
- 非チャンクエラーは reload せず `null` 描画（親は生存）
- `clearChunkReloadFlag` がフラグを消す

## 検証
- `pnpm test:run` → 6 files / **63 tests passed**
- `pnpm typecheck` ✅

## メモ
- jsdom は `location.reload` が non-configurable のため、テストでは `window.location` ごと差し替えて復元（happy-dom 不要、現行 jsdom 構成のまま）。
- 末尾句読点除去は **ASCII のみ**（全角 `、` 等は対象外）という実挙動をテストで明文化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)