### PR TITLE
fix: Firebase deploy CI を修復(project未設定 + service account 認証 / 監査#22)

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "kanban-relax"
+  }
+}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -7,7 +7,9 @@ on:
     paths:
       - 'firestore.rules'
       - 'firestore.indexes.json'
+      - '.firebaserc'
       - '.github/workflows/firebase-deploy.yml'
+  workflow_dispatch:
 
 jobs:
   deploy-firestore:
@@ -16,18 +18,41 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # 認証情報が無い場合はデプロイをスキップして警告のみ（赤バツにしない）。
+      # 旧構成は空の FIREBASE_TOKEN かつ project 未設定で常に失敗し、ルール/
+      # インデックスが一度も本番へ反映されていなかった。
+      - name: Check credentials
+        id: creds
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::FIREBASE_SERVICE_ACCOUNT secret 未設定のため Firestore ルール/インデックスのデプロイをスキップしました。本番には反映されません。設定手順は FIREBASE_CI_SETUP.md を参照してください。"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node.js
+        if: steps.creds.outputs.configured == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install Firebase CLI
+        if: steps.creds.outputs.configured == 'true'
         run: npm install -g firebase-tools
 
+      # サービスアカウント JSON を一時ファイルへ書き出し、GOOGLE_APPLICATION_CREDENTIALS
+      # 経由で認証する（firebase login:ci トークンは Google が非推奨化したため不採用: 監査#22）。
+      # project は .firebaserc の default に加えて明示指定する。
       - name: Deploy Firestore Rules & Indexes
+        if: steps.creds.outputs.configured == 'true'
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        # rules だけでなく indexes も deploy。アプリの本番クエリ
-        # (boards: userId+createdAt / cards: userId+order) は複合インデックス必須で、
-        # 未デプロイだと onSnapshot がインデックスエラーを投げオフラインに落ちる(監査C4)。
-        run: firebase deploy --only firestore:rules,firestore:indexes --token "$FIREBASE_TOKEN"
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          KEY_FILE="$RUNNER_TEMP/firebase-sa.json"
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$KEY_FILE"
+          export GOOGLE_APPLICATION_CREDENTIALS="$KEY_FILE"
+          firebase deploy --only firestore:rules,firestore:indexes --project kanban-relax --non-interactive
+          rm -f "$KEY_FILE"

--- a/FIREBASE_CI_SETUP.md
+++ b/FIREBASE_CI_SETUP.md
@@ -1,37 +1,59 @@
 # Firebase CI/CD セットアップ手順
 
-## 1. Firebase CI Token の取得
+Firestore のセキュリティルール（`firestore.rules`）と複合インデックス
+（`firestore.indexes.json`）を、`main` への push 時に自動デプロイするための設定。
 
-ターミナルで以下のコマンドを実行:
+> ⚠️ **重要:** `FIREBASE_SERVICE_ACCOUNT` secret を設定するまで、デプロイは
+> **スキップ**されます（ワークフローは警告付きで成功扱い）。設定が完了するまで
+> ルール/インデックスの変更は**本番に反映されません**。
+> 既存の変更を今すぐ反映したい場合は、後述の「手動デプロイ」を実行してください。
 
-```bash
-firebase login:ci
-```
+## 1. サービスアカウントの作成
 
-ブラウザが開くのでログインし、生成されたトークンをコピー
+`firebase login:ci` のトークン方式は Google が非推奨化したため、
+**サービスアカウント**を使う。
+
+1. [Google Cloud Console](https://console.cloud.google.com/) で対象プロジェクト
+   （`kanban-relax`）を開く
+2. IAM と管理 → サービスアカウント → 「サービスアカウントを作成」
+3. ロールに **Firebase Admin**（または最小権限なら
+   `Cloud Datastore Index Admin` + `Firebase Rules Admin`）を付与
+4. 作成したサービスアカウント → キー → 「鍵を追加」→ JSON を作成しダウンロード
 
 ## 2. GitHub Secrets に登録
 
-1. GitHubリポジトリページを開く
-2. Settings → Secrets and variables → Actions
-3. "New repository secret" をクリック
-4. Name: `FIREBASE_TOKEN`
-5. Secret: 先ほどコピーしたトークンを貼り付け
-6. "Add secret" をクリック
+1. GitHub リポジトリ → Settings → Secrets and variables → Actions
+2. "New repository secret"
+3. Name: `FIREBASE_SERVICE_ACCOUNT`
+4. Secret: ダウンロードした **JSON の中身をそのまま**貼り付け
+5. "Add secret"
 
 ## 3. 自動デプロイの動作
 
-以下のファイルが変更されると、自動的にFirebaseルールがデプロイされます:
+以下のファイルが `main` で変更されると自動デプロイされる:
+
 - `firestore.rules`
 - `firestore.indexes.json`
+- `.firebaserc`
+- `.github/workflows/firebase-deploy.yml`
 
-## 4. デプロイ状況の確認
+`workflow_dispatch` でも手動実行可能。
+
+## 4. 手動デプロイ（初回反映 / 緊急時）
+
+ローカルに Firebase CLI とログイン済み環境があれば:
+
+```bash
+firebase deploy --only firestore:rules,firestore:indexes --project kanban-relax
+```
+
+## 5. デプロイ状況の確認
 
 - GitHub Actions タブでワークフローの実行状況を確認
-- 失敗した場合はログを確認
+- secret 未設定の場合は「Check credentials」ステップに警告が出てスキップされる
 
 ## 注意事項
 
-- `FIREBASE_TOKEN`は絶対に公開しないこと
-- トークンが漏洩した場合は `firebase logout --token <TOKEN>` で無効化
-- 定期的にトークンを再生成することを推奨
+- `FIREBASE_SERVICE_ACCOUNT`（JSON 鍵）は絶対に公開しないこと
+- 鍵が漏洩した場合は Google Cloud Console から該当鍵を無効化し、再発行する
+- プロジェクト ID（`kanban-relax`）は `.firebaserc` の default で固定


### PR DESCRIPTION
## 発見した問題（重大）
`firebase-deploy` ワークフローは **過去の全実行が失敗**しており、Firestore の
**ルール / 複合インデックスが一度も本番へ自動デプロイされていなかった**。
失敗ログの原因は2点:

1. `FIREBASE_TOKEN` secret が空（`--token ""`）
2. `Error: No currently active project`（`.firebaserc`/`--project` 不在）

つまり監査で入れた **C4 のインデックス**・**C5 のルール強化**はリポジトリには
あるが**本番未反映**。本番のルール/インデックスは過去に手動デプロイされた状態のまま。

## 修正
- **`.firebaserc` を追加**し default project を `kanban-relax` に固定（「No active project」解消）
- 認証を **service account** 方式に刷新（`FIREBASE_SERVICE_ACCOUNT` を一時 JSON に書き出し
  `GOOGLE_APPLICATION_CREDENTIALS` で認証）。`firebase login:ci` トークンは Google 非推奨の
  ため不採用 — 監査の延期項目 **#22** もこれで解消
- secret **未設定時は warning を出してスキップ**（成功扱い、常時赤バツを回避）
- `deploy` に `--project kanban-relax --non-interactive` を明示
- トリガに `.firebaserc` と `workflow_dispatch` を追加
- `FIREBASE_CI_SETUP.md` を service account 手順へ全面更新

## ⚠️ マージ後に必要なあなたの操作（どちらか）
ルール/インデックスを**実際に本番反映**するには、CI に認証情報が要ります:

- **CI を有効化**: GCP でサービスアカウント(Firebase Admin)を作成 → JSON 鍵を
  `FIREBASE_SERVICE_ACCOUNT` secret に登録（手順は `FIREBASE_CI_SETUP.md`）。以後は自動。
- **今すぐ手動反映**: ローカルで `firebase deploy --only firestore:rules,firestore:indexes --project kanban-relax`

設定するまでデプロイは安全にスキップされます（本番は現状維持）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)