### PR TITLE
fix: 監査ランタイムバグ5件(useUrlMetadata無限ループ/stale memo/画像削除/順序衝突)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,9 @@ export function App() {
     const boards = useBoardStore((state) => state.boards)
     const columns = useMemo(() => {
         return getColumns(currentBoardId || undefined)
-    }, [getColumns, currentBoardId]) // boards は getColumns 内で参照されるため不要
+        // getColumns は安定参照なので boards を含めないと、同一 currentBoardId のまま
+        // レーンを追加/改名/並べ替え/削除しても再計算されず画面に反映されない(監査)。
+    }, [getColumns, currentBoardId, boards])
 
     const sensors = useSensors(
         useSensor(PointerSensor, {
@@ -278,7 +280,10 @@ export function App() {
                 // Dropping on a column - add to end of column
                 if (activeCard.columnId !== overColumn.id) {
                     const targetColumnCards = cardsByColumn[overColumn.id] || []
-                    const newOrder = targetColumnCards.length
+                    // order が連番でない(移動で穴が空いた)場合 .length が既存 order と衝突し
+                    // カードが重なる/入れ替わるため、addCard と同様 max(order)+1 で末尾を確定(監査)。
+                    const newOrder =
+                        targetColumnCards.length > 0 ? Math.max(...targetColumnCards.map((c) => c.order)) + 1 : 0
 
                     reorderCards([
                         {

--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -234,7 +234,9 @@ export const CardDetailModal = memo(function CardDetailModal({ card, onClose }: 
             dueDate: dueDate ? new Date(dueDate).getTime() : null,
             progress,
             color: cardColor,
-            images: images.length > 0 ? images : undefined,
+            // 全画像削除時は null を渡してフィールド削除を明示する。undefined だと
+            // Firestore 更新ペイロードから除外され、古い画像が消えず復活する(監査)。
+            images: images.length > 0 ? images : null,
         })
         onClose()
     }, [

--- a/src/ColumnManager.tsx
+++ b/src/ColumnManager.tsx
@@ -173,10 +173,13 @@ interface ColumnManagerProps {
 
 export const ColumnManager = memo(function ColumnManager({ boardId, onClose }: ColumnManagerProps) {
     const { getColumns, addColumn, removeColumn, updateColumn, reorderColumns } = useBoardStore()
+    const boards = useBoardStore((state) => state.boards)
     const { isDarkMode } = useThemeStore()
     const theme = getTheme(isDarkMode)
 
-    const columns = useMemo(() => getColumns(boardId), [getColumns, boardId])
+    // boards を deps に含めないと、getColumns/boardId が安定参照のためメモが初回で凍結し、
+    // レーンの追加/改名/並べ替え/削除がモーダルを開いている間に反映されない(監査)。
+    const columns = useMemo(() => getColumns(boardId), [getColumns, boardId, boards])
     const [newColumnTitle, setNewColumnTitle] = useState('')
 
     const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))

--- a/src/hooks/useUrlMetadata.test.tsx
+++ b/src/hooks/useUrlMetadata.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useUrlMetadata } from './useUrlMetadata'
+
+describe('useUrlMetadata', () => {
+    it('existingMetadata 省略時に無限ループしない（複数回 re-render しても安定）', () => {
+        // 既定引数 `= []` が不安定だと、再レンダリングのたびに setMetadata が走り
+        // "Maximum update depth exceeded" を投げる。安定参照ならここで例外は出ない。
+        const { result, rerender } = renderHook(({ text }) => useUrlMetadata(text), {
+            initialProps: { text: 'リンクを含まないテキスト' },
+        })
+        expect(result.current.metadata).toEqual([])
+        rerender({ text: 'リンクを含まないテキスト' })
+        rerender({ text: 'まだリンクは無い' })
+        expect(result.current.metadata).toEqual([])
+    })
+
+    it('existingMetadata 省略時は metadata の参照が再レンダリング間で安定する', () => {
+        const { result, rerender } = renderHook(() => useUrlMetadata('plain text'))
+        const first = result.current.metadata
+        rerender()
+        // 参照が据え置かれていること（不安定だと毎回新しい配列になる）
+        expect(result.current.metadata).toBe(first)
+    })
+})

--- a/src/hooks/useUrlMetadata.ts
+++ b/src/hooks/useUrlMetadata.ts
@@ -4,6 +4,11 @@ import type { UrlMetadata } from '../types'
 
 const DEBOUNCE_DELAY_MS = 500 // デバウンス遅延時間（500ms）
 
+// 安定した空配列参照。デフォルト引数 `= []` は呼び出し側が undefined を渡すたびに
+// 新しい配列を生成し、それが effect の依存になって無限再レンダリング
+// （Maximum update depth exceeded）とデバウンスタイマーの永久リセットを引き起こす。
+const EMPTY_METADATA: UrlMetadata[] = []
+
 /**
  * メタデータ配列を比較する
  */
@@ -22,14 +27,15 @@ function areMetadataArraysEqual(a: UrlMetadata[], b: UrlMetadata[]): boolean {
  */
 export function useUrlMetadata(
     text: string,
-    existingMetadata: UrlMetadata[] = [],
+    existingMetadata: UrlMetadata[] = EMPTY_METADATA,
     onMetadataUpdate?: (metadata: UrlMetadata[]) => void
 ) {
     const [metadata, setMetadata] = useState<UrlMetadata[]>(existingMetadata)
 
-    // existingMetadataが変更されたら同期
+    // existingMetadataが変更されたら同期。内容が同一なら state を据え置き、
+    // 参照だけ変わった場合の不要な再レンダリング/フェッチ済みデータの上書きを防ぐ。
     useEffect(() => {
-        setMetadata(existingMetadata)
+        setMetadata((prev) => (areMetadataArraysEqual(prev, existingMetadata) ? prev : existingMetadata))
     }, [existingMetadata])
 
     useEffect(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,7 @@ export interface Card {
     dueDate?: number | null // nullは明示的な削除を表す
     progress?: number
     urlMetadata?: UrlMetadata[] // URL メタ情報のキャッシュ
-    images?: ImageAttachment[] // 貼り付け画像
+    images?: ImageAttachment[] | null // 貼り付け画像（nullは明示的な削除を表す）
 }
 
 export interface Column {


### PR DESCRIPTION
残タスク監査で確認されたランタイム不具合のうち、**安全に直せる5件**をまとめて修正。

## 🔴 HIGH: useUrlMetadata 無限レンダリングループ
`useUrlMetadata(text, existingMetadata = [], ...)` の既定引数 `[]` が、リンクの無いカード(`card.urlMetadata === undefined`)で**毎レンダリング新しい配列**を生成。これが sync effect の依存になり `setMetadata(new []) → 再レンダリング → …` の自己持続ループ(**Maximum update depth exceeded**)を発生させ、デバウンスタイマーも毎回リセットされてメタデータ取得も永久に走らない。カード詳細を開いて入力すると壊れる。
- 修正: モジュールレベル定数 `EMPTY_METADATA` を既定に、sync effect を内容比較ガード付きに。**回帰テスト追加**。

## MED: stale `columns` useMemo ×2(App.tsx / ColumnManager.tsx)
`getColumns` は zustand の安定参照のため、deps が `[getColumns, currentBoardId]`/`[getColumns, boardId]` だと **boards が変わっても再計算されない**。レーンの追加/改名/並べ替え/削除や Firestore 更新が画面/レーン編集 UI に反映されない。
- 修正: `boards` を購読し deps に追加。

## MED: 全画像削除が Firebase で永続化されない
`images: ... : undefined` は Firestore 更新ペイロードから除外され、古い画像が `onSnapshot` で復活。`dueDate` と同じく **null = 明示削除** の規約に揃え `images: ... : null` に。`Card.images` 型を `| null` に拡張。

## LOW: ドロップ末尾の order 衝突
列に穴が空いていると `.length` が既存 order と衝突しカードが重なる/入れ替わる。`addCard` と同じ `max(order)+1` に。

## 検証
- `pnpm typecheck` ✅ / `pnpm build` ✅ / `pnpm test:run` → **65 tests** ✅ / `pnpm test:e2e`(smoke) ✅

監査の残り(a11y/テスト整備/設定ハードニング)は後続PRで。要判断項目(キーボードDnD・allorigins・base64画像>1MiB 等)は報告に留めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)