### PR TITLE
fix: 監査a11y(モーダルaria名/フォーカス復帰/IME変換Enter/focus-visible)

### DIFF
--- a/src/BaseModal.tsx
+++ b/src/BaseModal.tsx
@@ -9,6 +9,9 @@ interface BaseModalProps {
     children: ReactNode
     maxWidth?: string
     mobileAlignTop?: boolean
+    // ダイアログのアクセシブル名。id='modal-title' を持たないモーダルはこれを渡す。
+    // 未指定時は従来どおり aria-labelledby='modal-title' を参照する(監査)。
+    ariaLabel?: string
 }
 
 // iOS判定（iPhone, iPad, macOS Safari）
@@ -26,6 +29,7 @@ export const BaseModal = memo(function BaseModal({
     children,
     maxWidth = '600px',
     mobileAlignTop = false,
+    ariaLabel,
 }: BaseModalProps) {
     const { isDarkMode } = useThemeStore()
     const theme = getTheme(isDarkMode)
@@ -35,6 +39,9 @@ export const BaseModal = memo(function BaseModal({
     useEffect(() => {
         const modal = modalRef.current
         if (!modal) return
+
+        // モーダルを開いたトリガー要素を控え、閉じる時にフォーカスを戻す(監査)。
+        const previouslyFocused = document.activeElement as HTMLElement | null
 
         const getFocusableElements = () => {
             return Array.from(
@@ -79,6 +86,8 @@ export const BaseModal = memo(function BaseModal({
 
         return () => {
             document.removeEventListener('keydown', handleTab)
+            // 閉じた後、開く前にフォーカスしていた要素へ戻す（キーボード位置を失わない）。
+            previouslyFocused?.focus?.()
         }
     }, [])
 
@@ -128,7 +137,8 @@ export const BaseModal = memo(function BaseModal({
                 $maxWidth={maxWidth}
                 role='dialog'
                 aria-modal='true'
-                aria-labelledby='modal-title'
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabel ? undefined : 'modal-title'}
             >
                 {children}
             </Modal>

--- a/src/BoardModal.tsx
+++ b/src/BoardModal.tsx
@@ -16,6 +16,7 @@ import {
 import { useBoardStore } from './store/boardStore'
 import { useThemeStore } from './store/themeStore'
 import { getTheme, Theme } from './theme'
+import { isComposing } from './utils/keyboard'
 import { BOARD_COLORS, LABEL_COLORS } from './constants'
 import { BaseModal } from './BaseModal'
 import type { Label } from './types'
@@ -227,6 +228,7 @@ export const BoardModal = memo(function BoardModal({ boardId, onClose }: BoardMo
 
     const handleLabelKeyPress = useCallback(
         (e: React.KeyboardEvent) => {
+            if (isComposing(e)) return
             if (e.key === 'Enter') {
                 e.preventDefault()
                 handleAddLabel()
@@ -389,7 +391,7 @@ export const BoardModal = memo(function BoardModal({ boardId, onClose }: BoardMo
     }, [boardId, deleteBoard, onClose])
 
     return (
-        <BaseModal onClose={onClose} maxWidth='500px'>
+        <BaseModal onClose={onClose} maxWidth='500px' ariaLabel={boardId ? 'ボードを編集' : '新しいボード'}>
             <ModalContent $theme={theme}>
                 <Header $theme={theme}>
                     <Title $theme={theme}>{boardId ? 'ボードを編集' : '新しいボード'}</Title>

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -341,4 +341,10 @@ const DeleteButton = styled.button.attrs({
         color: ${color.Red};
         opacity: 1 !important;
     }
+
+    /* キーボードフォーカス時も表示。opacity:0 のままだと focus-visible の輪郭も隠れる(監査) */
+    &:focus-visible {
+        color: ${color.Red};
+        opacity: 1 !important;
+    }
 `

--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -12,6 +12,7 @@ import { useThemeStore } from './store/themeStore'
 import { getTheme, Theme } from './theme'
 import { CARD_COLOR_LABELS } from './constants'
 import { getDueDateStatus } from './utils/dateUtils'
+import { isComposing } from './utils/keyboard'
 import { BaseModal } from './BaseModal'
 import { LinkedText } from './LinkedText'
 import { useUrlMetadata } from './hooks/useUrlMetadata'
@@ -83,6 +84,7 @@ function SortableChecklistItem({
                         value={editingText}
                         onChange={(e) => onEditTextChange(e.target.value)}
                         onKeyDown={(e) => {
+                            if (isComposing(e)) return
                             if (e.key === 'Enter') {
                                 onSaveEdit()
                             } else if (e.key === 'Escape') {
@@ -577,7 +579,7 @@ export const CardDetailModal = memo(function CardDetailModal({ card, onClose }: 
                                 type='text'
                                 value={newChecklistItem}
                                 onChange={(e) => setNewChecklistItem(e.target.value)}
-                                onKeyDown={(e) => e.key === 'Enter' && addChecklistItem()}
+                                onKeyDown={(e) => !isComposing(e) && e.key === 'Enter' && addChecklistItem()}
                                 placeholder='新しい項目を追加...'
                                 $theme={theme}
                             />

--- a/src/Column.tsx
+++ b/src/Column.tsx
@@ -309,4 +309,10 @@ const CollapseButton = styled.button<{ $theme: Theme; $columnColor?: string }>`
         color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 1)' : props.$theme.text)};
         background: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 0.15)' : props.$theme.surfaceHover)};
     }
+
+    /* キーボードフォーカス時も表示（opacity:0 だと focus-visible の輪郭が見えない: 監査） */
+    &:focus-visible {
+        opacity: 1 !important;
+        color: ${(props) => (props.$columnColor ? 'rgba(255, 255, 255, 1)' : props.$theme.text)};
+    }
 `

--- a/src/ColumnManager.tsx
+++ b/src/ColumnManager.tsx
@@ -9,6 +9,7 @@ import { PrimaryButton, SecondaryButton } from './Button'
 import { useBoardStore } from './store/boardStore'
 import { useThemeStore } from './store/themeStore'
 import { getTheme, Theme } from './theme'
+import { isComposing } from './utils/keyboard'
 import type { ColumnDefinition } from './types'
 
 // レーンの色パレット (jewel tones)
@@ -82,6 +83,7 @@ const SortableColumnItem = memo(function SortableColumnItem({
                     onChange={(e) => setEditTitle(e.target.value)}
                     onBlur={handleSaveEdit}
                     onKeyDown={(e) => {
+                        if (isComposing(e)) return
                         if (e.key === 'Enter') handleSaveEdit()
                         if (e.key === 'Escape') {
                             setEditTitle(column.title)
@@ -225,7 +227,7 @@ export const ColumnManager = memo(function ColumnManager({ boardId, onClose }: C
     )
 
     return (
-        <BaseModal onClose={onClose} maxWidth='500px'>
+        <BaseModal onClose={onClose} maxWidth='500px' ariaLabel='レーン管理'>
             <ModalContent $theme={theme}>
                 <Header $theme={theme}>
                     <ModalTitle $theme={theme}>レーン管理</ModalTitle>
@@ -264,7 +266,7 @@ export const ColumnManager = memo(function ColumnManager({ boardId, onClose }: C
                             type='text'
                             value={newColumnTitle}
                             onChange={(e) => setNewColumnTitle(e.target.value)}
-                            onKeyDown={(e) => e.key === 'Enter' && handleAddColumn()}
+                            onKeyDown={(e) => !isComposing(e) && e.key === 'Enter' && handleAddColumn()}
                             placeholder='新しいレーン名を入力...'
                             $theme={theme}
                             aria-label='新しいレーン名を入力'

--- a/src/TrashModal.tsx
+++ b/src/TrashModal.tsx
@@ -87,7 +87,7 @@ export const TrashModal = memo(function TrashModal({ onClose }: TrashModalProps)
     }, [])
 
     return (
-        <BaseModal onClose={onClose} maxWidth='600px'>
+        <BaseModal onClose={onClose} maxWidth='600px' ariaLabel='ゴミ箱'>
             <ModalContent $theme={theme}>
                 <Header $theme={theme}>
                     <Title $theme={theme}>ゴミ箱</Title>


### PR DESCRIPTION
監査の a11y 指摘のうち、構造的で安全な4種をまとめて修正。

## HIGH: ダイアログのアクセシブル名が3/4のモーダルで空
`BaseModal` が `aria-labelledby='modal-title'` を固定参照していたが、`id='modal-title'` を持つのは CardDetailModal のみ。TrashModal/BoardModal/ColumnManager はダングリング参照で**名前が空**だった。`BaseModal` に `ariaLabel` prop を追加し3モーダルから明示（CardDetailModal は従来どおり labelledby）。

## MED: モーダルを閉じてもトリガーにフォーカスが戻らない
`BaseModal` が開く前の `document.activeElement` を控え、閉じる時に復帰。キーボード位置を失わない（WCAG/ARIA APG）。

## MED: IME変換確定の Enter が半確定テキストを誤送信
日本語入力中の Enter で確定途中のテキストが送信される典型バグ。既存 `isComposing()` ガードを5箇所に適用：チェックリスト追加/編集、レーン追加/編集、ラベル追加。

## MED: opacity:0 のアイコンボタンがキーボードフォーカスで不可視
カード削除ボタン / レーン折りたたみボタンは `opacity:0` で hover 時のみ表示 → focus-visible の輪郭も隠れる。`&:focus-visible { opacity: 1 }` を追加（WCAG 2.4.7）。

## 検証
- `pnpm typecheck` ✅ / `pnpm test:run`(65) ✅ / `pnpm test:e2e`(smoke) ✅

残りの a11y(コントラスト, タブ/スウォッチの role, 説明欄のキーボード編集, モバイルメニュー)は後続。要判断(キーボードDnD等)は報告のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)