### PR TITLE
test: store/keyboard のデータ整合性ロジックに単体テスト62件(監査)

### DIFF
--- a/src/store/boardStore.test.ts
+++ b/src/store/boardStore.test.ts
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest'
+import { DEFAULT_COLUMNS } from '../types'
+import type { Board, ColumnDefinition } from '../types'
+
+const STORAGE_KEY = 'kanban-boards'
+const CURRENT_BOARD_KEY = 'kanban-current-board'
+
+// This jsdom environment exposes a `localStorage` object with NO working methods,
+// so boardStore captures `localStorageAvailable === false` at module load and would
+// fall back to private in-memory state we cannot reset between tests. We install a
+// working Map-based localStorage BEFORE importing boardStore so it captures
+// `localStorageAvailable === true` and reads/writes the storage we fully control.
+let backing: Map<string, string>
+function installLocalStorage(): void {
+    backing = new Map()
+    const mock = {
+        getItem: (key: string): string | null => (backing.has(key) ? (backing.get(key) ?? null) : null),
+        setItem: (key: string, value: string): void => {
+            backing.set(key, String(value))
+        },
+        removeItem: (key: string): void => {
+            backing.delete(key)
+        },
+        clear: (): void => {
+            backing.clear()
+        },
+        key: (index: number): string | null => Array.from(backing.keys())[index] ?? null,
+        get length(): number {
+            return backing.size
+        },
+    }
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: mock })
+}
+
+// Loaded lazily after the localStorage mock is in place.
+let useBoardStore: typeof import('./boardStore').useBoardStore
+
+beforeAll(async () => {
+    installLocalStorage()
+    const mod = await import('./boardStore')
+    useBoardStore = mod.useBoardStore
+})
+
+function makeBoard(overrides: Partial<Board> = {}): Board {
+    return {
+        id: 'board-1',
+        name: 'Test Board',
+        description: '',
+        color: '#0079BF',
+        labels: [],
+        columns: [],
+        createdAt: 1,
+        updatedAt: 1,
+        ...overrides,
+    }
+}
+
+function cols(...defs: ColumnDefinition[]): ColumnDefinition[] {
+    return defs
+}
+
+describe('boardStore', () => {
+    beforeEach(() => {
+        // Required reset shape for the BoardState slice under test.
+        useBoardStore.setState({ boards: [], currentBoardId: null, forceOfflineMode: true })
+        localStorage.clear()
+    })
+
+    describe('getColumns', () => {
+        it('returns columns sorted by order', () => {
+            const board = makeBoard({
+                columns: cols(
+                    { id: 'c', title: 'C', order: 2 },
+                    { id: 'a', title: 'A', order: 0 },
+                    { id: 'b', title: 'B', order: 1 }
+                ),
+            })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            const result = useBoardStore.getState().getColumns(board.id)
+            expect(result.map((c) => c.id)).toEqual(['a', 'b', 'c'])
+        })
+
+        it('uses currentBoardId when no boardId is passed', () => {
+            const board = makeBoard({
+                columns: cols({ id: 'y', title: 'Y', order: 1 }, { id: 'x', title: 'X', order: 0 }),
+            })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            const result = useBoardStore.getState().getColumns()
+            expect(result.map((c) => c.id)).toEqual(['x', 'y'])
+        })
+
+        it('returns a defensive copy (does not mutate the stored columns order)', () => {
+            const stored = cols(
+                { id: 'c', title: 'C', order: 2 },
+                { id: 'a', title: 'A', order: 0 },
+                { id: 'b', title: 'B', order: 1 }
+            )
+            const board = makeBoard({ columns: stored })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            const result = useBoardStore.getState().getColumns(board.id)
+            // A new array is returned, not the stored reference.
+            expect(result).not.toBe(stored)
+            // Sorting the returned array did not reorder the original stored array.
+            expect(stored.map((c) => c.id)).toEqual(['c', 'a', 'b'])
+        })
+
+        it('falls back to DEFAULT_COLUMNS when the board has an empty columns array', () => {
+            const board = makeBoard({ columns: [] })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            expect(useBoardStore.getState().getColumns(board.id)).toEqual(DEFAULT_COLUMNS)
+        })
+
+        it('falls back to DEFAULT_COLUMNS when the board has no columns field', () => {
+            const board = makeBoard({ columns: undefined })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            expect(useBoardStore.getState().getColumns(board.id)).toEqual(DEFAULT_COLUMNS)
+        })
+
+        it('falls back to DEFAULT_COLUMNS when the board id is unknown', () => {
+            expect(useBoardStore.getState().getColumns('nope')).toEqual(DEFAULT_COLUMNS)
+        })
+    })
+
+    describe('removeColumn', () => {
+        it('refuses to remove when only 1 column remains', async () => {
+            const board = makeBoard({
+                columns: cols({ id: 'only', title: 'Only', order: 0 }),
+            })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            await useBoardStore.getState().removeColumn(board.id, 'only')
+
+            const after = useBoardStore.getState().boards[0].columns
+            expect(after).toHaveLength(1)
+            expect(after?.[0].id).toBe('only')
+        })
+
+        it('reindexes order to a contiguous 0..n-1 range after removal', async () => {
+            const board = makeBoard({
+                columns: cols(
+                    { id: 'a', title: 'A', order: 0 },
+                    { id: 'b', title: 'B', order: 5 },
+                    { id: 'c', title: 'C', order: 9 }
+                ),
+            })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            await useBoardStore.getState().removeColumn(board.id, 'b')
+
+            const after = useBoardStore.getState().boards[0].columns ?? []
+            expect(after.map((c) => c.id)).toEqual(['a', 'c'])
+            expect(after.map((c) => c.order)).toEqual([0, 1])
+        })
+
+        it('does nothing for an unknown board', async () => {
+            const board = makeBoard({
+                columns: cols({ id: 'a', title: 'A', order: 0 }, { id: 'b', title: 'B', order: 1 }),
+            })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            await useBoardStore.getState().removeColumn('missing', 'a')
+
+            expect(useBoardStore.getState().boards[0].columns).toHaveLength(2)
+        })
+    })
+
+    describe('addColumn', () => {
+        it('appends a new column with order = columns.length', async () => {
+            const board = makeBoard({
+                columns: cols({ id: 'a', title: 'A', order: 0 }, { id: 'b', title: 'B', order: 1 }),
+            })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            await useBoardStore.getState().addColumn(board.id, 'New', '#ff0000')
+
+            const after = useBoardStore.getState().boards[0].columns ?? []
+            expect(after).toHaveLength(3)
+            const appended = after[2]
+            expect(appended.title).toBe('New')
+            expect(appended.order).toBe(2)
+            expect(appended.color).toBe('#ff0000')
+            expect(appended.id).toBeTruthy()
+        })
+
+        it('appends onto DEFAULT_COLUMNS when the board has no columns', async () => {
+            const board = makeBoard({ columns: undefined })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            await useBoardStore.getState().addColumn(board.id, 'Extra')
+
+            const after = useBoardStore.getState().boards[0].columns ?? []
+            expect(after).toHaveLength(DEFAULT_COLUMNS.length + 1)
+            expect(after[after.length - 1].order).toBe(DEFAULT_COLUMNS.length)
+            expect(after[after.length - 1].title).toBe('Extra')
+        })
+    })
+
+    describe('reorderColumns', () => {
+        it('recomputes contiguous order from the supplied array order', async () => {
+            const a: ColumnDefinition = { id: 'a', title: 'A', order: 0 }
+            const b: ColumnDefinition = { id: 'b', title: 'B', order: 1 }
+            const c: ColumnDefinition = { id: 'c', title: 'C', order: 2 }
+            const board = makeBoard({ columns: cols(a, b, c) })
+            useBoardStore.setState({ boards: [board], currentBoardId: board.id, forceOfflineMode: true })
+
+            // New visual order: c, a, b
+            await useBoardStore.getState().reorderColumns(board.id, [c, a, b])
+
+            const after = useBoardStore.getState().boards[0].columns ?? []
+            expect(after.map((col) => col.id)).toEqual(['c', 'a', 'b'])
+            expect(after.map((col) => col.order)).toEqual([0, 1, 2])
+        })
+    })
+
+    describe('initializeOfflineMode', () => {
+        it('creates a default board with DEFAULT_COLUMNS when none exist', () => {
+            useBoardStore.getState().initializeOfflineMode()
+
+            const state = useBoardStore.getState()
+            expect(state.boards).toHaveLength(1)
+            expect(state.boards[0].name).toBe('マイボード')
+            expect(state.boards[0].columns).toEqual(DEFAULT_COLUMNS)
+            expect(state.forceOfflineMode).toBe(true)
+            // First board is auto-selected as current.
+            expect(state.currentBoardId).toBe(state.boards[0].id)
+            // Persisted to (mock) localStorage.
+            const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as Board[]
+            expect(persisted).toHaveLength(1)
+            expect(localStorage.getItem(CURRENT_BOARD_KEY)).toBe(state.boards[0].id)
+        })
+
+        it('back-fills DEFAULT_COLUMNS onto a legacy board seeded without columns', () => {
+            const legacy = {
+                id: 'legacy-1',
+                name: 'Legacy',
+                description: '',
+                color: '#0079BF',
+                labels: [],
+                createdAt: 1,
+                updatedAt: 1,
+            }
+            localStorage.setItem(STORAGE_KEY, JSON.stringify([legacy]))
+
+            useBoardStore.getState().initializeOfflineMode()
+
+            const state = useBoardStore.getState()
+            expect(state.boards).toHaveLength(1)
+            expect(state.boards[0].id).toBe('legacy-1')
+            expect(state.boards[0].columns).toEqual(DEFAULT_COLUMNS)
+            // Migration is persisted back to storage.
+            const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as Board[]
+            expect(persisted[0].columns).toEqual(DEFAULT_COLUMNS)
+            // First board selected as current when none was stored.
+            expect(state.currentBoardId).toBe('legacy-1')
+        })
+
+        it('leaves an already-migrated board untouched', () => {
+            const existing = makeBoard({
+                id: 'kept',
+                columns: cols({ id: 'x', title: 'X', order: 0 }, { id: 'y', title: 'Y', order: 1 }),
+            })
+            localStorage.setItem(STORAGE_KEY, JSON.stringify([existing]))
+
+            useBoardStore.getState().initializeOfflineMode()
+
+            const state = useBoardStore.getState()
+            expect(state.boards).toHaveLength(1)
+            expect(state.boards[0].columns?.map((c) => c.id)).toEqual(['x', 'y'])
+        })
+    })
+})

--- a/src/store/kanbanStore.test.ts
+++ b/src/store/kanbanStore.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useKanbanStore } from './kanbanStore'
+import { useTrashStore } from './trashStore'
+import { useAuthStore } from './authStore'
+import type { Card } from '../types'
+
+// Build a fully-typed Card with sensible defaults that callers can override.
+function makeCard(over: Partial<Card> = {}): Card {
+    return {
+        id: 'card-default',
+        text: 'card',
+        columnId: 'TODO',
+        boardId: 'b1',
+        order: 0,
+        createdAt: 0,
+        updatedAt: 0,
+        ...over,
+    }
+}
+
+describe('kanbanStore (offline / localStorage mode)', () => {
+    beforeEach(() => {
+        // jsdom's localStorage in this env lacks a usable clear(); install a Map-based mock
+        // (same pattern as themeStore.test.ts). setItem/removeItem still work so the store's
+        // module-level localStorageAvailable check stays true and writes hit this mock.
+        const store = new Map<string, string>()
+        const mock: Storage = {
+            getItem: (key: string) => store.get(key) ?? null,
+            setItem: (key: string, value: string) => {
+                store.set(key, value)
+            },
+            removeItem: (key: string) => {
+                store.delete(key)
+            },
+            clear: () => {
+                store.clear()
+            },
+            get length() {
+                return store.size
+            },
+            key: (index: number) => Array.from(store.keys())[index] ?? null,
+        }
+        Object.defineProperty(window, 'localStorage', { configurable: true, value: mock })
+
+        // Force the pure-localStorage branch so no Firebase write/onSnapshot runs.
+        useKanbanStore.setState({ cards: [], forceOfflineMode: true, isLoading: false, error: null })
+        useTrashStore.setState({ trashedCards: [] })
+        // Null user is fine for addCard (userId becomes undefined and is dropped).
+        useAuthStore.setState({ user: null })
+        localStorage.clear()
+    })
+
+    describe('addCard', () => {
+        it('sets order to max(order)+1 scoped to the SAME column AND board', async () => {
+            useKanbanStore.setState({
+                cards: [
+                    makeCard({ id: 'a', columnId: 'TODO', boardId: 'b1', order: 0 }),
+                    makeCard({ id: 'b', columnId: 'TODO', boardId: 'b1', order: 5 }),
+                    // Different board, same column -> must be ignored even though order is high.
+                    makeCard({ id: 'c', columnId: 'TODO', boardId: 'b2', order: 99 }),
+                    // Same board, different column -> must be ignored.
+                    makeCard({ id: 'd', columnId: 'Done', boardId: 'b1', order: 50 }),
+                ],
+            })
+
+            await useKanbanStore.getState().addCard('new card', 'TODO', 'b1')
+
+            const cards = useKanbanStore.getState().cards
+            const created = cards.find((c) => c.text === 'new card')
+            expect(created).toBeDefined()
+            // max(TODO@b1) = 5 -> 6, not influenced by b2 (99) or Done (50)
+            expect(created?.order).toBe(6)
+            expect(created?.columnId).toBe('TODO')
+            expect(created?.boardId).toBe('b1')
+        })
+
+        it('uses order 0 when the target column/board is empty', async () => {
+            useKanbanStore.setState({
+                cards: [makeCard({ id: 'x', columnId: 'TODO', boardId: 'b1', order: 10 })],
+            })
+
+            await useKanbanStore.getState().addCard('first in Done', 'Done', 'b1')
+
+            const created = useKanbanStore.getState().cards.find((c) => c.text === 'first in Done')
+            expect(created?.order).toBe(0)
+        })
+    })
+
+    describe('moveCard', () => {
+        it('updates columnId/order of the target card only', async () => {
+            useKanbanStore.setState({
+                cards: [
+                    makeCard({ id: 'target', columnId: 'TODO', boardId: 'b1', order: 0 }),
+                    makeCard({ id: 'other', columnId: 'TODO', boardId: 'b1', order: 1 }),
+                ],
+            })
+
+            await useKanbanStore.getState().moveCard('target', 'Done', 3)
+
+            const cards = useKanbanStore.getState().cards
+            const target = cards.find((c) => c.id === 'target')
+            const other = cards.find((c) => c.id === 'other')
+            expect(target?.columnId).toBe('Done')
+            expect(target?.order).toBe(3)
+            // Untouched card stays exactly as before.
+            expect(other?.columnId).toBe('TODO')
+            expect(other?.order).toBe(1)
+        })
+    })
+
+    describe('reorderCards', () => {
+        it('applies each update including the optional columnId', async () => {
+            useKanbanStore.setState({
+                cards: [
+                    makeCard({ id: 'x', columnId: 'TODO', boardId: 'b1', order: 0 }),
+                    makeCard({ id: 'y', columnId: 'TODO', boardId: 'b1', order: 1 }),
+                    makeCard({ id: 'z', columnId: 'Done', boardId: 'b1', order: 0 }),
+                ],
+            })
+
+            await useKanbanStore.getState().reorderCards([
+                { id: 'x', order: 2, columnId: 'Done' }, // order + column change
+                { id: 'y', order: 0 }, // order only, column unchanged
+            ])
+
+            const cards = useKanbanStore.getState().cards
+            const x = cards.find((c) => c.id === 'x')
+            const y = cards.find((c) => c.id === 'y')
+            const z = cards.find((c) => c.id === 'z')
+
+            expect(x?.order).toBe(2)
+            expect(x?.columnId).toBe('Done')
+
+            expect(y?.order).toBe(0)
+            expect(y?.columnId).toBe('TODO') // no columnId in update -> preserved
+
+            // Card not listed in updates is untouched.
+            expect(z?.order).toBe(0)
+            expect(z?.columnId).toBe('Done')
+        })
+    })
+
+    describe('restoreCard', () => {
+        it('inserts a card without trash-only fields and with order=max+1 in the target column', async () => {
+            useKanbanStore.setState({
+                cards: [
+                    makeCard({ id: 'existing', columnId: 'TODO', boardId: 'b1', order: 7 }),
+                    // Different column/board to confirm scoping of max().
+                    makeCard({ id: 'noise', columnId: 'Done', boardId: 'b1', order: 99 }),
+                ],
+            })
+
+            // A trashed-shaped card carrying the trash-only fields.
+            const trashed = {
+                ...makeCard({ id: 'restore-me', columnId: 'OldCol', boardId: 'old-board', order: 3 }),
+                deletedAt: 123456,
+                originalBoardId: 'old-board',
+                originalColumnId: 'OldCol',
+            } as Card
+
+            await useKanbanStore.getState().restoreCard(trashed, 'b1', 'TODO')
+
+            const restored = useKanbanStore.getState().cards.find((c) => c.id === 'restore-me')
+            expect(restored).toBeDefined()
+            // order = max(TODO@b1)=7 -> 8
+            expect(restored?.order).toBe(8)
+            expect(restored?.boardId).toBe('b1')
+            expect(restored?.columnId).toBe('TODO')
+            // Trash-only fields must be stripped.
+            expect('deletedAt' in (restored as Card)).toBe(false)
+            expect('originalBoardId' in (restored as Card)).toBe(false)
+            expect('originalColumnId' in (restored as Card)).toBe(false)
+            // Original id preserved.
+            expect(restored?.id).toBe('restore-me')
+        })
+    })
+
+    describe('updateCard', () => {
+        it('deletes a field when its update value is null (offline null-delete loop)', async () => {
+            useKanbanStore.setState({
+                cards: [
+                    makeCard({ id: 'u1', columnId: 'TODO', boardId: 'b1', order: 0, color: 'red', dueDate: 12345 }),
+                ],
+            })
+
+            // dueDate is typed `number | null`; null triggers the for..in delete loop.
+            await useKanbanStore.getState().updateCard('u1', { dueDate: null })
+
+            const updated = useKanbanStore.getState().cards.find((c) => c.id === 'u1')
+            expect(updated).toBeDefined()
+            // Field removed entirely, not set to null.
+            expect('dueDate' in (updated as Card)).toBe(false)
+            // Unrelated field preserved.
+            expect(updated?.color).toBe('red')
+        })
+    })
+
+    describe('deleteCard', () => {
+        it('moves the card into the trash store and removes it from cards', async () => {
+            const card = makeCard({ id: 'del-1', columnId: 'TODO', boardId: 'b1', order: 0, text: 'to delete' })
+            useKanbanStore.setState({
+                cards: [card, makeCard({ id: 'keep', columnId: 'TODO', boardId: 'b1', order: 1 })],
+            })
+
+            await useKanbanStore.getState().deleteCard('del-1')
+
+            const cards = useKanbanStore.getState().cards
+            expect(cards.some((c) => c.id === 'del-1')).toBe(false)
+            expect(cards.some((c) => c.id === 'keep')).toBe(true)
+
+            // Pushed into the trash store via addToTrash with trash metadata.
+            const trashed = useTrashStore.getState().trashedCards
+            expect(trashed).toHaveLength(1)
+            expect(trashed[0].id).toBe('del-1')
+            expect(trashed[0].originalBoardId).toBe('b1')
+            expect(trashed[0].originalColumnId).toBe('TODO')
+            expect(typeof trashed[0].deletedAt).toBe('number')
+        })
+    })
+})

--- a/src/store/trashStore.test.ts
+++ b/src/store/trashStore.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useTrashStore, type TrashedCard } from './trashStore'
+import type { Card } from '../types'
+
+// Fixed clock anchor for deterministic time math
+const NOW = new Date('2026-06-28T00:00:00.000Z').getTime()
+const ONE_HOUR = 60 * 60 * 1000
+const ONE_DAY = 24 * ONE_HOUR
+const THIRTY_DAYS = 30 * ONE_DAY
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+    return {
+        id: 'card-1',
+        text: 'hello world',
+        columnId: 'TODO',
+        boardId: 'board-1',
+        order: 0,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    }
+}
+
+function makeTrashedCard(overrides: Partial<TrashedCard> = {}): TrashedCard {
+    return {
+        ...makeCard(),
+        deletedAt: NOW,
+        originalBoardId: 'board-1',
+        originalColumnId: 'TODO',
+        ...overrides,
+    }
+}
+
+describe('trashStore', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(NOW)
+        // NOTE: in this jsdom env `localStorage` has no Storage methods, so the
+        // store resolves localStorageAvailable=false at import and uses its
+        // in-memory fallback. Persistence is therefore unobservable via a
+        // localStorage spy; we reset only the zustand state (real state shape).
+        useTrashStore.setState({ trashedCards: [] })
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.restoreAllMocks()
+    })
+
+    describe('getDaysUntilPermanentDeletion', () => {
+        it('returns 30 when deletedAt is now', () => {
+            const { getDaysUntilPermanentDeletion } = useTrashStore.getState()
+            expect(getDaysUntilPermanentDeletion(NOW)).toBe(30)
+        })
+
+        it('returns 1 just under the 30-day boundary', () => {
+            const { getDaysUntilPermanentDeletion } = useTrashStore.getState()
+            // elapsed = 30 days minus 1 hour -> ~1 hour remaining -> ceil to 1
+            const deletedAt = NOW - (THIRTY_DAYS - ONE_HOUR)
+            expect(getDaysUntilPermanentDeletion(deletedAt)).toBe(1)
+        })
+
+        it('returns 0 once past the 30-day boundary', () => {
+            const { getDaysUntilPermanentDeletion } = useTrashStore.getState()
+            const deletedAt = NOW - (THIRTY_DAYS + ONE_DAY)
+            expect(getDaysUntilPermanentDeletion(deletedAt)).toBe(0)
+        })
+    })
+
+    describe('cleanupExpiredCards', () => {
+        it('keeps a 29-day-old card and removes a 31-day-old card', () => {
+            const fresh = makeTrashedCard({ id: 'fresh', deletedAt: NOW - 29 * ONE_DAY })
+            const stale = makeTrashedCard({ id: 'stale', deletedAt: NOW - 31 * ONE_DAY })
+            useTrashStore.setState({ trashedCards: [fresh, stale] })
+
+            useTrashStore.getState().cleanupExpiredCards()
+
+            const { trashedCards } = useTrashStore.getState()
+            expect(trashedCards).toHaveLength(1)
+            expect(trashedCards[0].id).toBe('fresh')
+        })
+
+        it('does NOT re-persist when nothing changed (length + reference preserved)', () => {
+            const fresh = makeTrashedCard({ id: 'fresh', deletedAt: NOW - 29 * ONE_DAY })
+            const before = [fresh]
+            useTrashStore.setState({ trashedCards: before })
+
+            useTrashStore.getState().cleanupExpiredCards()
+
+            const after = useTrashStore.getState().trashedCards
+            // Guard short-circuits: set() is never called, so length is unchanged
+            // AND the exact same array reference is kept (no re-persist work done).
+            expect(after).toHaveLength(1)
+            expect(after).toBe(before)
+        })
+
+        it('replaces the array (re-persists) when a card is removed', () => {
+            const stale = makeTrashedCard({ id: 'stale', deletedAt: NOW - 31 * ONE_DAY })
+            const before = [stale]
+            useTrashStore.setState({ trashedCards: before })
+
+            useTrashStore.getState().cleanupExpiredCards()
+
+            const after = useTrashStore.getState().trashedCards
+            expect(after).toHaveLength(0)
+            expect(after).not.toBe(before)
+        })
+    })
+
+    describe('addToTrash', () => {
+        it('stamps deletedAt and the original board/column ids', () => {
+            const card = makeCard({ id: 'to-trash', boardId: 'board-9', columnId: 'Doing' })
+            useTrashStore.getState().addToTrash(card)
+
+            const { trashedCards } = useTrashStore.getState()
+            expect(trashedCards).toHaveLength(1)
+            const trashed = trashedCards[0]
+            expect(trashed.id).toBe('to-trash')
+            expect(trashed.deletedAt).toBe(NOW)
+            expect(trashed.originalBoardId).toBe('board-9')
+            expect(trashed.originalColumnId).toBe('Doing')
+        })
+    })
+
+    describe('restoreFromTrash', () => {
+        it('returns the matching card and removes only it', () => {
+            const a = makeTrashedCard({ id: 'a' })
+            const b = makeTrashedCard({ id: 'b' })
+            useTrashStore.setState({ trashedCards: [a, b] })
+
+            const restored = useTrashStore.getState().restoreFromTrash('a')
+
+            expect(restored).not.toBeNull()
+            expect(restored?.id).toBe('a')
+            const { trashedCards } = useTrashStore.getState()
+            expect(trashedCards).toHaveLength(1)
+            expect(trashedCards[0].id).toBe('b')
+        })
+
+        it('returns null for an unknown id and leaves the trash untouched', () => {
+            const a = makeTrashedCard({ id: 'a' })
+            useTrashStore.setState({ trashedCards: [a] })
+
+            const restored = useTrashStore.getState().restoreFromTrash('missing')
+
+            expect(restored).toBeNull()
+            expect(useTrashStore.getState().trashedCards).toHaveLength(1)
+        })
+    })
+
+    describe('permanentlyDelete', () => {
+        it('removes only the targeted card', () => {
+            const a = makeTrashedCard({ id: 'a' })
+            const b = makeTrashedCard({ id: 'b' })
+            useTrashStore.setState({ trashedCards: [a, b] })
+
+            useTrashStore.getState().permanentlyDelete('a')
+
+            const { trashedCards } = useTrashStore.getState()
+            expect(trashedCards).toHaveLength(1)
+            expect(trashedCards[0].id).toBe('b')
+        })
+    })
+})

--- a/src/utils/keyboard.test.ts
+++ b/src/utils/keyboard.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { isComposing, isInputElement, isModifierKey, isShortcutKey } from './keyboard'
+
+// --- Test helpers -----------------------------------------------------------
+
+type EventProps = {
+    key: string
+    metaKey?: boolean
+    ctrlKey?: boolean
+    shiftKey?: boolean
+    altKey?: boolean
+    isComposing?: boolean
+}
+
+// Builds a React.KeyboardEvent-like object (has `nativeEvent`, matching the
+// SyntheticEvent branch the source checks via `'nativeEvent' in e`).
+function makeReactEvent(p: EventProps): ReactKeyboardEvent {
+    const nativeEvent = { isComposing: p.isComposing ?? false } as unknown as KeyboardEvent
+    return {
+        key: p.key,
+        metaKey: p.metaKey ?? false,
+        ctrlKey: p.ctrlKey ?? false,
+        shiftKey: p.shiftKey ?? false,
+        altKey: p.altKey ?? false,
+        nativeEvent,
+    } as unknown as ReactKeyboardEvent
+}
+
+// Builds a native KeyboardEvent-like object (NO `nativeEvent` property, so the
+// source falls through to the native branch reading `e.isComposing`).
+function makeNativeEvent(p: { key?: string; isComposing?: boolean }): KeyboardEvent {
+    return {
+        key: p.key ?? 'a',
+        isComposing: p.isComposing ?? false,
+    } as unknown as KeyboardEvent
+}
+
+const originalPlatform = window.navigator.platform
+
+function setPlatform(platform: string): void {
+    Object.defineProperty(window.navigator, 'platform', {
+        configurable: true,
+        value: platform,
+    })
+}
+
+describe('keyboard utils', () => {
+    afterEach(() => {
+        // Restore platform and clear any focused/appended elements between tests.
+        setPlatform(originalPlatform)
+        document.body.replaceChildren()
+        if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur()
+        }
+    })
+
+    describe('isComposing', () => {
+        it('returns true when React nativeEvent.isComposing is true', () => {
+            expect(isComposing(makeReactEvent({ key: 'a', isComposing: true }))).toBe(true)
+        })
+
+        it('returns false when React nativeEvent.isComposing is false', () => {
+            expect(isComposing(makeReactEvent({ key: 'a', isComposing: false }))).toBe(false)
+        })
+
+        it('returns true for a native event with isComposing true', () => {
+            expect(isComposing(makeNativeEvent({ isComposing: true }))).toBe(true)
+        })
+
+        it('returns false for a native event with isComposing false', () => {
+            expect(isComposing(makeNativeEvent({ isComposing: false }))).toBe(false)
+        })
+    })
+
+    describe('isInputElement', () => {
+        it('returns false for null', () => {
+            expect(isInputElement(null)).toBe(false)
+        })
+
+        it('returns true for input', () => {
+            expect(isInputElement(document.createElement('input'))).toBe(true)
+        })
+
+        it('returns true for textarea', () => {
+            expect(isInputElement(document.createElement('textarea'))).toBe(true)
+        })
+
+        it('returns true for select', () => {
+            expect(isInputElement(document.createElement('select'))).toBe(true)
+        })
+
+        it('returns true for a contenteditable element', () => {
+            const div = document.createElement('div')
+            div.setAttribute('contenteditable', 'true')
+            expect(isInputElement(div)).toBe(true)
+        })
+
+        it('returns false for a plain div', () => {
+            expect(isInputElement(document.createElement('div'))).toBe(false)
+        })
+
+        it('returns false for a div with contenteditable="false"', () => {
+            const div = document.createElement('div')
+            div.setAttribute('contenteditable', 'false')
+            expect(isInputElement(div)).toBe(false)
+        })
+    })
+
+    describe('isModifierKey', () => {
+        it('reads metaKey on Mac', () => {
+            setPlatform('MacIntel')
+            expect(isModifierKey(makeReactEvent({ key: 'k', metaKey: true }))).toBe(true)
+            expect(isModifierKey(makeReactEvent({ key: 'k', ctrlKey: true }))).toBe(false)
+        })
+
+        it('reads ctrlKey on non-Mac', () => {
+            setPlatform('Win32')
+            expect(isModifierKey(makeReactEvent({ key: 'k', ctrlKey: true }))).toBe(true)
+            expect(isModifierKey(makeReactEvent({ key: 'k', metaKey: true }))).toBe(false)
+        })
+    })
+
+    describe('isShortcutKey', () => {
+        it('matches Cmd+K on Mac', () => {
+            setPlatform('MacIntel')
+            expect(isShortcutKey(makeReactEvent({ key: 'k', metaKey: true }), 'k')).toBe(true)
+        })
+
+        it('does not match Cmd+K on non-Mac (metaKey ignored)', () => {
+            setPlatform('Win32')
+            expect(isShortcutKey(makeReactEvent({ key: 'k', metaKey: true }), 'k')).toBe(false)
+        })
+
+        it('matches Ctrl+K on non-Mac', () => {
+            setPlatform('Win32')
+            expect(isShortcutKey(makeReactEvent({ key: 'k', ctrlKey: true }), 'k')).toBe(true)
+        })
+
+        it('does not match Ctrl+K on Mac (ctrlKey ignored)', () => {
+            setPlatform('MacIntel')
+            expect(isShortcutKey(makeReactEvent({ key: 'k', ctrlKey: true }), 'k')).toBe(false)
+        })
+
+        it('returns false while IME composing even with the right modifier', () => {
+            setPlatform('MacIntel')
+            expect(isShortcutKey(makeReactEvent({ key: 'k', metaKey: true, isComposing: true }), 'k')).toBe(false)
+        })
+
+        describe('when an input element is focused', () => {
+            let input: HTMLInputElement
+
+            beforeEach(() => {
+                setPlatform('MacIntel')
+                input = document.createElement('input')
+                document.body.appendChild(input)
+                input.focus()
+            })
+
+            it('confirms the input is the active element', () => {
+                expect(document.activeElement).toBe(input)
+            })
+
+            it('blocks a plain "k" shortcut', () => {
+                // Focus on an input short-circuits non-Enter keys to false,
+                // even when the modifier is held.
+                expect(isShortcutKey(makeReactEvent({ key: 'k', metaKey: true }), 'k')).toBe(false)
+            })
+
+            it('still allows modifier+Enter (submit) while focused', () => {
+                expect(isShortcutKey(makeReactEvent({ key: 'Enter', metaKey: true }), 'Enter')).toBe(true)
+            })
+
+            it('blocks plain Enter (no modifier) while focused', () => {
+                expect(isShortcutKey(makeReactEvent({ key: 'Enter' }), 'Enter')).toBe(false)
+            })
+        })
+
+        it('returns false when the key does not match', () => {
+            setPlatform('MacIntel')
+            expect(isShortcutKey(makeReactEvent({ key: 'j', metaKey: true }), 'k')).toBe(false)
+        })
+
+        describe('requireModifier option', () => {
+            it('requireModifier:false matches a bare key with no modifier', () => {
+                setPlatform('MacIntel')
+                expect(isShortcutKey(makeReactEvent({ key: 'k' }), 'k', { requireModifier: false })).toBe(true)
+            })
+
+            it('requireModifier:false rejects when a modifier IS pressed (inverted branch)', () => {
+                setPlatform('MacIntel')
+                expect(
+                    isShortcutKey(makeReactEvent({ key: 'k', metaKey: true }), 'k', {
+                        requireModifier: false,
+                    })
+                ).toBe(false)
+            })
+        })
+
+        describe('requireShift option', () => {
+            it('default (requireShift:false) rejects when shift IS pressed (inverted branch)', () => {
+                setPlatform('MacIntel')
+                expect(isShortcutKey(makeReactEvent({ key: 'k', metaKey: true, shiftKey: true }), 'k')).toBe(false)
+            })
+
+            it('requireShift:true matches when shift is pressed', () => {
+                setPlatform('MacIntel')
+                expect(
+                    isShortcutKey(makeReactEvent({ key: 'k', metaKey: true, shiftKey: true }), 'k', {
+                        requireShift: true,
+                    })
+                ).toBe(true)
+            })
+
+            it('requireShift:true rejects when shift is NOT pressed', () => {
+                setPlatform('MacIntel')
+                expect(
+                    isShortcutKey(makeReactEvent({ key: 'k', metaKey: true }), 'k', {
+                        requireShift: true,
+                    })
+                ).toBe(false)
+            })
+        })
+
+        describe('requireAlt option', () => {
+            it('requireAlt:true matches when alt is pressed', () => {
+                setPlatform('MacIntel')
+                expect(
+                    isShortcutKey(makeReactEvent({ key: 'k', metaKey: true, altKey: true }), 'k', {
+                        requireAlt: true,
+                    })
+                ).toBe(true)
+            })
+
+            it('requireAlt:true rejects when alt is NOT pressed', () => {
+                setPlatform('MacIntel')
+                expect(
+                    isShortcutKey(makeReactEvent({ key: 'k', metaKey: true }), 'k', {
+                        requireAlt: true,
+                    })
+                ).toBe(false)
+            })
+        })
+    })
+})


### PR DESCRIPTION
監査で「最も価値が高く未テスト」と指摘された**ピュアなデータ整合性ロジック**を網羅。回帰の代償が大きく、Firebase 非依存でテスト可能なものを優先。**62件追加(計65→127)**。

並列の subagent ワークフローで4ファイルを生成し、各自 vitest で自己検証→最後に全127件を一括 green 確認。

## 追加テスト
- **trashStore (10)** — 30日ソフト削除: `getDaysUntilPermanentDeletion` の境界(30/1/0)、`cleanupExpiredCards`(29日残す/31日消す/不変時は再永続化しない)、`addToTrash` スタンプ、`restoreFromTrash`/`permanentlyDelete` の対象限定。
- **kanbanStore (7)** — オフライン分岐: `addCard` order=max+1(列×ボードスコープ)、`moveCard`、`reorderCards`(optional columnId)、`restoreCard`(trashフィールド除去)、`updateCard` の null フィールド削除、`deleteCard`→trash 連携。
- **boardStore (15)** — `getColumns` ソート+DEFAULT_COLUMNS フォールバック、`removeColumn`(最小1列保証+order 再採番)、`addColumn`/`reorderColumns`、`initializeOfflineMode`(既定ボード生成+レガシー列バックフィル移行)。
- **keyboard (30)** — `isComposing`/`isInputElement`/`isModifierKey`/`isShortcutKey`(Mac・非Mac、入力中ガード、modifier+Enter 許容、requireModifier/Shift/Alt 各分岐)。

## 環境メモ
当 jsdom 環境は `localStorage` のメソッドが無効。各ストアはモジュールロード時に `localStorageAvailable=false` を捕捉しインメモリ・フォールバックに切替わるため、テストはストア状態(`getState()`)を真実源として検証(必要箇所は Map ベース localStorage を `defineProperty` で注入)。Firebase/onSnapshot には一切触れない。

## 検証
- `pnpm test:run` → 11 files / **127 tests passed** ✅ / `pnpm typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)