### PR TITLE
fix: 監査a11y(セマンティクス): モバイルメニュー状態/説明欄キーボード/タブ・色スウォッチ role

### DIFF
--- a/src/BoardModal.tsx
+++ b/src/BoardModal.tsx
@@ -401,11 +401,13 @@ export const BoardModal = memo(function BoardModal({ boardId, onClose }: BoardMo
                 </Header>
 
                 {boardId && (
-                    <TabBar $theme={theme}>
+                    <TabBar $theme={theme} role='tablist' aria-label='ボード設定'>
                         <Tab
                             $active={activeTab === 'basic'}
                             $theme={theme}
                             onClick={() => setActiveTab('basic')}
+                            role='tab'
+                            aria-selected={activeTab === 'basic'}
                             aria-label='基本情報タブ'
                         >
                             基本情報
@@ -414,6 +416,8 @@ export const BoardModal = memo(function BoardModal({ boardId, onClose }: BoardMo
                             $active={activeTab === 'labels'}
                             $theme={theme}
                             onClick={() => setActiveTab('labels')}
+                            role='tab'
+                            aria-selected={activeTab === 'labels'}
                             aria-label='ラベル管理タブ'
                         >
                             ラベル管理
@@ -458,6 +462,9 @@ export const BoardModal = memo(function BoardModal({ boardId, onClose }: BoardMo
                                         $isDarkMode={isDarkMode}
                                         onClick={() => setSelectedColor(boardColor)}
                                         type='button'
+                                        aria-label={`ボードカラー ${boardColor}`}
+                                        aria-pressed={selectedColor === boardColor}
+                                        title={boardColor}
                                     />
                                 ))}
                             </ColorGrid>

--- a/src/CardDetailModal.tsx
+++ b/src/CardDetailModal.tsx
@@ -486,7 +486,16 @@ export const CardDetailModal = memo(function CardDetailModal({ card, onClose }: 
                             <DescriptionDisplay
                                 $theme={theme}
                                 onClick={() => setEditingDescription(true)}
-                                title='クリックして編集'
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault()
+                                        setEditingDescription(true)
+                                    }
+                                }}
+                                role='button'
+                                tabIndex={0}
+                                title='クリックまたはEnterで編集'
+                                aria-label='説明を編集'
                             >
                                 <LinkedText text={description} metadata={metadata} theme={theme} />
                             </DescriptionDisplay>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -125,6 +125,9 @@ export const Header = memo(function Header({ className }: { className?: string }
                 }}
                 title='メニュー'
                 aria-label='メニュー'
+                aria-expanded={isMenuOpen}
+                aria-controls='mobile-menu-drawer'
+                aria-haspopup='menu'
                 data-menu-container
             >
                 {isMenuOpen ? <CloseIcon /> : <MenuIcon />}
@@ -133,7 +136,14 @@ export const Header = memo(function Header({ className }: { className?: string }
             {/* モバイルメニュードロワー */}
             {isMenuOpen && (
                 <MobileMenuOverlay onClick={() => setIsMenuOpen(false)}>
-                    <MobileMenu onClick={(e) => e.stopPropagation()} data-menu-container $isDarkMode={isDarkMode}>
+                    <MobileMenu
+                        id='mobile-menu-drawer'
+                        role='menu'
+                        aria-label='メニュー'
+                        onClick={(e) => e.stopPropagation()}
+                        data-menu-container
+                        $isDarkMode={isDarkMode}
+                    >
                         <MenuSection>
                             <MenuSectionTitle>ボード</MenuSectionTitle>
                             <BoardSelector />


### PR DESCRIPTION
監査の残り a11y 指摘のうち、**視覚変更を伴わない ARIA/キーボード追加**のみをまとめて対応(コントラスト色調整・カラーピッカーの roving tabindex は別途/要判断として保留)。

- **モバイルメニュー(Header)**: ハンバーガーに `aria-expanded`/`aria-controls`/`aria-haspopup`、ドロワーに `id`/`role='menu'`/`aria-label`。開閉状態を支援技術へ公開。
- **既存説明文の編集(CardDetailModal)**: クリックのみだった編集起動に `role='button'` + `tabIndex` + Enter/Space ハンドラ + `aria-label`。キーボードで編集可能に(WCAG 2.1.1)。
- **ボード設定タブ(BoardModal)**: `role='tablist'/'tab'` + `aria-selected`。選択状態が色のみ→プログラム的に公開(WCAG 1.4.1/4.1.2)。
- **ボードカラースウォッチ(BoardModal)**: `aria-label`(色値)+ `aria-pressed`。無名 button → 名前と選択状態を付与。

## 検証
- `pnpm typecheck` ✅ / `pnpm test:run`(127) ✅ / `pnpm test:e2e`(smoke) ✅

## 監査の残り(報告)
- **視覚(要レビュー)**: 期限バッジ色 #FF9F1A/#FF4136 と opacity ありの二次テキストが light モードで AA 未満 → テーマ条件付きの色調整が必要。
- **要判断(自動修正しない)**: カードDnDのキーボード対応、カラーピッカーの radiogroup+roving tabindex、allorigins への URL 流出、base64画像>1MiB、firestore フィールド検証、ai-auto-fix の @main ピン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)